### PR TITLE
Improve Docker Swarm and Compose support

### DIFF
--- a/cmd/cupdate/main.go
+++ b/cmd/cupdate/main.go
@@ -323,7 +323,7 @@ func main() {
 							Type:   string(n.Kind()),
 							Name:   n.Name(),
 						}
-						if node.Type() == "docker/"+docker.ResourceKindSwarmNamespace {
+						if node.Type() == "docker/"+docker.ResourceKindSwarmNamespace || node.Type() == "docker/"+docker.ResourceKindComposeProject {
 							namespaceNode = &node
 						}
 					case platform.ImageNode:

--- a/internal/platform/docker/platform.go
+++ b/internal/platform/docker/platform.go
@@ -240,7 +240,7 @@ func (p *Platform) Graph(ctx context.Context) (*graph.Graph[platform.Node], erro
 			},
 		}
 
-		// Add graph nodes for Docker Swarm, if available
+		// Add graph nodes for Docker Swarm and Compose, if available
 		if container.Labels != nil {
 			if taskID, ok := container.Labels["com.docker.swarm.task.id"]; ok {
 				taskName, ok := container.Labels["com.docker.swarm.task.name"]
@@ -266,6 +266,12 @@ func (p *Platform) Graph(ctx context.Context) (*graph.Graph[platform.Node], erro
 					id:   fmt.Sprintf("docker/swarm/service/%s", serviceID),
 					name: serviceName,
 				})
+			} else if service, ok := container.Labels["com.docker.compose.service"]; ok {
+				tree = append(tree, resource{
+					kind: ResourceKindComposeService,
+					id:   fmt.Sprintf("docker/compose/service/%s", service),
+					name: service,
+				})
 			}
 
 			if namespace, ok := container.Labels["com.docker.stack.namespace"]; ok {
@@ -273,6 +279,12 @@ func (p *Platform) Graph(ctx context.Context) (*graph.Graph[platform.Node], erro
 					kind: ResourceKindSwarmNamespace,
 					id:   fmt.Sprintf("docker/swarm/namespace/%s", namespace),
 					name: namespace,
+				})
+			} else if project, ok := container.Labels["com.docker.compose.project"]; ok {
+				tree = append(tree, resource{
+					kind: ResourceKindComposeProject,
+					id:   fmt.Sprintf("docker/compose/project/%s", project),
+					name: project,
 				})
 			}
 		}

--- a/internal/platform/docker/resources.go
+++ b/internal/platform/docker/resources.go
@@ -13,6 +13,8 @@ const (
 	ResourceKindSwarmTask      = "swarm/task"
 	ResourceKindSwarmService   = "swarm/service"
 	ResourceKindSwarmNamespace = "swarm/namespace"
+	ResourceKindComposeProject = "compose/project"
+	ResourceKindComposeService = "compose/service"
 )
 
 type Resource interface {
@@ -58,6 +60,10 @@ func TagName(kind ResourceKind) string {
 		return "service"
 	case ResourceKindSwarmNamespace:
 		return "namespace"
+	case ResourceKindComposeProject:
+		return "project"
+	case ResourceKindComposeService:
+		return "service"
 	default:
 		// Panic as missing entries would be a programming issue, not runtime
 		// bug

--- a/internal/platform/docker/resources.go
+++ b/internal/platform/docker/resources.go
@@ -9,7 +9,10 @@ import (
 type ResourceKind string
 
 const (
-	ResourceKindContainer = "container"
+	ResourceKindContainer      = "container"
+	ResourceKindSwarmTask      = "swarm/task"
+	ResourceKindSwarmService   = "swarm/service"
+	ResourceKindSwarmNamespace = "swarm/namespace"
 )
 
 type Resource interface {
@@ -49,6 +52,12 @@ func TagName(kind ResourceKind) string {
 	switch kind {
 	case ResourceKindContainer:
 		return "container"
+	case ResourceKindSwarmTask:
+		return "task"
+	case ResourceKindSwarmService:
+		return "service"
+	case ResourceKindSwarmNamespace:
+		return "namespace"
 	default:
 		// Panic as missing entries would be a programming issue, not runtime
 		// bug

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/AlexGustafsson/cupdate/internal/httputil"
 	"github.com/AlexGustafsson/cupdate/internal/models"
 	"github.com/AlexGustafsson/cupdate/internal/oci"
+	"github.com/AlexGustafsson/cupdate/internal/platform/docker"
 	"github.com/AlexGustafsson/cupdate/internal/platform/kubernetes"
 	"github.com/AlexGustafsson/cupdate/internal/semver"
 	"github.com/AlexGustafsson/cupdate/internal/store"
@@ -139,7 +140,9 @@ func (w *Worker) ProcessRawImage(ctx context.Context, reference oci.Reference) e
 				data.InsertTag(node.Name)
 			}
 		case "docker":
-			// Not implemented
+			if node.Type == docker.ResourceKindSwarmNamespace {
+				data.InsertTag(node.Name)
+			}
 		}
 	}
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -112,9 +112,9 @@ func (w *Worker) ProcessRawImage(ctx context.Context, reference oci.Reference) e
 	// Add some basic tags
 	if data.LatestReference != nil {
 		if data.ImageReference.String() == data.LatestReference.String() {
-			data.Tags = append(data.Tags, "up-to-date")
+			data.InsertTag("up-to-date")
 		} else {
-			data.Tags = append(data.Tags, "outdated")
+			data.InsertTag("outdated")
 		}
 
 		// Add tags based on version diff
@@ -123,7 +123,7 @@ func (w *Worker) ProcessRawImage(ctx context.Context, reference oci.Reference) e
 		if currentVersion != nil && currentVersionErr == nil && newVersion != nil && newVersionErr == nil {
 			diff := currentVersion.Diff(newVersion)
 			if diff != "" {
-				data.Tags = append(data.Tags, diff)
+				data.InsertTag(diff)
 			}
 
 			versionDiffSortable = semver.PackInt64(newVersion) - semver.PackInt64(currentVersion)

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -142,6 +142,8 @@ func (w *Worker) ProcessRawImage(ctx context.Context, reference oci.Reference) e
 		case "docker":
 			if node.Type == docker.ResourceKindSwarmNamespace {
 				data.InsertTag("namespace:" + node.Name)
+			} else if node.Type == docker.ResourceKindComposeProject {
+				data.InsertTag("project:" + node.Name)
 			}
 		}
 	}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/AlexGustafsson/cupdate/internal/httputil"
 	"github.com/AlexGustafsson/cupdate/internal/models"
 	"github.com/AlexGustafsson/cupdate/internal/oci"
+	"github.com/AlexGustafsson/cupdate/internal/platform/kubernetes"
 	"github.com/AlexGustafsson/cupdate/internal/semver"
 	"github.com/AlexGustafsson/cupdate/internal/store"
 	"github.com/AlexGustafsson/cupdate/internal/workflow/imageworkflow"
@@ -127,6 +128,18 @@ func (w *Worker) ProcessRawImage(ctx context.Context, reference oci.Reference) e
 			}
 
 			versionDiffSortable = semver.PackInt64(newVersion) - semver.PackInt64(currentVersion)
+		}
+	}
+
+	// Add Kubernetes namespace and Docker stack tags
+	for _, node := range image.Graph.Nodes {
+		switch node.Domain {
+		case "kubernetes":
+			if node.Type == kubernetes.ResourceKindCoreV1Namespace {
+				data.InsertTag(node.Name)
+			}
+		case "docker":
+			// Not implemented
 		}
 	}
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -137,11 +137,11 @@ func (w *Worker) ProcessRawImage(ctx context.Context, reference oci.Reference) e
 		switch node.Domain {
 		case "kubernetes":
 			if node.Type == kubernetes.ResourceKindCoreV1Namespace {
-				data.InsertTag(node.Name)
+				data.InsertTag("namespace:" + node.Name)
 			}
 		case "docker":
 			if node.Type == docker.ResourceKindSwarmNamespace {
-				data.InsertTag(node.Name)
+				data.InsertTag("namespace:" + node.Name)
 			}
 		}
 	}

--- a/web/components/Badge.tsx
+++ b/web/components/Badge.tsx
@@ -13,7 +13,7 @@ export function Badge({
   className,
   ...rest
 }: Omit<HTMLAttributes<HTMLSpanElement>, 'color'> & BadgeProps): JSX.Element {
-  let backgroundColor = '#CC5889'
+  let backgroundColor = 'light-dark(#3A3FCE, #4349f0)'
   if (typeof color === 'string') {
     backgroundColor = color
   } else if (color !== undefined) {

--- a/web/components/ImageCard.tsx
+++ b/web/components/ImageCard.tsx
@@ -1,7 +1,7 @@
 import type { JSX } from 'react'
 
 import { NavLink, useNavigate } from 'react-router-dom'
-import { TagsByName, sortTags } from '../tags'
+import { TagsByName, compareTags } from '../tags'
 import { formatRelativeTimeTo } from '../time'
 import { Badge } from './Badge'
 import { ImageLogo } from './ImageLogo'
@@ -91,22 +91,24 @@ export function ImageCard({
         )}
         <p className="text-sm mt-2">{description}</p>
         <div className="flex flex-wrap gap-2 mt-4">
-          {tags.toSorted(sortTags).map((x) => (
-            <Badge
-              key={x}
-              label={x}
-              color={TagsByName[x]?.color}
-              className="hover:opacity-90"
-              // It's illegal to nest anchors in HTML, so unfortunately we need
-              // to use onClick here
-              onClick={(e) => {
-                e.metaKey || e.ctrlKey
-                  ? openTab(`/?tag=${encodeURIComponent(x)}`)
-                  : navigate(`/?tag=${encodeURIComponent(x)}`)
-                e.preventDefault()
-              }}
-            />
-          ))}
+          {tags
+            .toSorted((a, b) => compareTags(a, b))
+            .map((x) => (
+              <Badge
+                key={x}
+                label={x}
+                color={TagsByName[x]?.color}
+                className="hover:opacity-90"
+                // It's illegal to nest anchors in HTML, so unfortunately we need
+                // to use onClick here
+                onClick={(e) => {
+                  e.metaKey || e.ctrlKey
+                    ? openTab(`/?tag=${encodeURIComponent(x)}`)
+                    : navigate(`/?tag=${encodeURIComponent(x)}`)
+                  e.preventDefault()
+                }}
+              />
+            ))}
         </div>
       </div>
     </div>

--- a/web/components/ImageCard.tsx
+++ b/web/components/ImageCard.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from 'react'
 
-import { NavLink } from 'react-router-dom'
+import { NavLink, useNavigate } from 'react-router-dom'
 import { TagsByName, sortTags } from '../tags'
 import { formatRelativeTimeTo } from '../time'
 import { Badge } from './Badge'
@@ -32,6 +32,8 @@ export function ImageCard({
   tags,
   className,
 }: ImageCardProps & { className?: string }): JSX.Element {
+  const navigate = useNavigate()
+
   return (
     <div
       className={`flex gap-x-4 p-4 md:p-6 bg-white dark:bg-[#1e1e1e] rounded-lg shadow ${className || ''}`}
@@ -90,16 +92,34 @@ export function ImageCard({
         <p className="text-sm mt-2">{description}</p>
         <div className="flex flex-wrap gap-2 mt-4">
           {tags.toSorted(sortTags).map((x) => (
-            <NavLink key={x} to={`/?tag=${encodeURIComponent(x)}`}>
-              <Badge
-                label={x}
-                color={TagsByName[x]?.color}
-                className="hover:opacity-90"
-              />
-            </NavLink>
+            <Badge
+              key={x}
+              label={x}
+              color={TagsByName[x]?.color}
+              className="hover:opacity-90"
+              // It's illegal to nest anchors in HTML, so unfortunately we need
+              // to use onClick here
+              onClick={(e) => {
+                e.metaKey || e.ctrlKey
+                  ? openTab(`/?tag=${encodeURIComponent(x)}`)
+                  : navigate(`/?tag=${encodeURIComponent(x)}`)
+                e.preventDefault()
+              }}
+            />
           ))}
         </div>
       </div>
     </div>
   )
+}
+
+function openTab(target: string) {
+  // Using window.open with target _blank creates a new window on Safari, macOS
+  // so use this cross-platform solution instead
+  const a = document.createElement('a')
+
+  a.rel = 'noreferrer'
+  a.target = '_blank'
+  a.href = target
+  a.click()
 }

--- a/web/components/ImageCard.tsx
+++ b/web/components/ImageCard.tsx
@@ -1,7 +1,7 @@
 import type { JSX } from 'react'
 
 import { NavLink } from 'react-router-dom'
-import { TagsByName } from '../tags'
+import { TagsByName, sortTags } from '../tags'
 import { formatRelativeTimeTo } from '../time'
 import { Badge } from './Badge'
 import { ImageLogo } from './ImageLogo'
@@ -89,7 +89,7 @@ export function ImageCard({
         )}
         <p className="text-sm mt-2">{description}</p>
         <div className="flex flex-wrap gap-2 mt-4">
-          {tags.map((x) => (
+          {tags.toSorted(sortTags).map((x) => (
             <NavLink key={x} to={`/?tag=${encodeURIComponent(x)}`}>
               <Badge
                 label={x}

--- a/web/components/TagSelect.tsx
+++ b/web/components/TagSelect.tsx
@@ -1,6 +1,6 @@
 import { type JSX, type PropsWithChildren, useRef, useState } from 'react'
 
-import { type Tag, sortTags } from '../tags'
+import { type Tag, compareTags } from '../tags'
 import { Badge } from './Badge'
 
 const IOS = [
@@ -39,11 +39,13 @@ export function TagSelect({
             )
           }
         >
-          {tags.toSorted(sortTags).map((x) => (
-            <option key={x.name} value={x.name}>
-              {x.name}
-            </option>
-          ))}
+          {tags
+            .toSorted((a, b) => compareTags(a.name, b.name))
+            .map((x) => (
+              <option key={x.name} value={x.name}>
+                {x.name}
+              </option>
+            ))}
         </select>
         <svg
           role="img"
@@ -97,28 +99,37 @@ export function TagSelect({
       {isOpen && (
         <div className="absolute group-hover:visible -top-4 -left-4 p-2 z-50 text-black dark:text-[#dddddd]">
           <div className="flex max-h-64 overflow-y-auto flex-col gap-y-2 py-2 px-3 pr-6 bg-white dark:bg-[#292929] border-solid border-[1px] border-[#d0d0d0]/95 dark:border-[#505050] rounded-lg w-max shadow">
-            {tags.toSorted(sortTags).map((x) => (
-              <label key={x.name} className="cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={filter.includes(x.name)}
-                  onChange={(e) =>
-                    onChange((current) =>
-                      e.target.checked
-                        ? [...current, x.name]
-                        : current.filter((y) => y !== x.name)
-                    )
-                  }
-                  className="scale-125 cursor-pointer"
-                />
-                <Badge
-                  title={x.description}
-                  label={x.name}
-                  color={x.color}
-                  className="ml-2"
-                />
-              </label>
-            ))}
+            {tags
+              .toSorted((a, b) =>
+                compareTags(
+                  a.name,
+                  b.name,
+                  filter.includes(a.name),
+                  filter.includes(b.name)
+                )
+              )
+              .map((x) => (
+                <label key={x.name} className="cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={filter.includes(x.name)}
+                    onChange={(e) =>
+                      onChange((current) =>
+                        e.target.checked
+                          ? [...current, x.name]
+                          : current.filter((y) => y !== x.name)
+                      )
+                    }
+                    className="scale-125 cursor-pointer"
+                  />
+                  <Badge
+                    title={x.description}
+                    label={x.name}
+                    color={x.color}
+                    className="ml-2"
+                  />
+                </label>
+              ))}
           </div>
         </div>
       )}

--- a/web/components/TagSelect.tsx
+++ b/web/components/TagSelect.tsx
@@ -1,6 +1,6 @@
 import { type JSX, type PropsWithChildren, useRef, useState } from 'react'
 
-import type { Tag } from '../tags'
+import { type Tag, sortTags } from '../tags'
 import { Badge } from './Badge'
 
 const IOS = [
@@ -11,17 +11,6 @@ const IOS = [
   'iPhone',
   'iPod',
 ].includes(navigator.platform)
-
-/** Sort tags lexically, putting prefixed tags last. */
-function sortTags(a: Tag, b: Tag): number {
-  if (a.name.includes(':') === b.name.includes(':')) {
-    return a.name.localeCompare(b.name)
-  } else if (a.name.includes(':')) {
-    return 1
-  } else {
-    return -1
-  }
-}
 
 export function TagSelect({
   tags,

--- a/web/components/TagSelect.tsx
+++ b/web/components/TagSelect.tsx
@@ -107,7 +107,7 @@ export function TagSelect({
       </svg>
       {isOpen && (
         <div className="absolute group-hover:visible -top-4 -left-4 p-2 z-50 text-black dark:text-[#dddddd]">
-          <div className="flex flex-col gap-y-2 py-2 px-3 pr-6 bg-white dark:bg-[#292929] border-solid border-[1px] border-[#d0d0d0]/95 dark:border-[#505050] rounded-lg w-max shadow">
+          <div className="flex max-h-64 overflow-y-auto flex-col gap-y-2 py-2 px-3 pr-6 bg-white dark:bg-[#292929] border-solid border-[1px] border-[#d0d0d0]/95 dark:border-[#505050] rounded-lg w-max shadow">
             {tags.toSorted(sortTags).map((x) => (
               <label key={x.name} className="cursor-pointer">
                 <input

--- a/web/components/TagSelect.tsx
+++ b/web/components/TagSelect.tsx
@@ -12,6 +12,17 @@ const IOS = [
   'iPod',
 ].includes(navigator.platform)
 
+/** Sort tags lexically, putting prefixed tags last. */
+function sortTags(a: Tag, b: Tag): number {
+  if (a.name.includes(':') === b.name.includes(':')) {
+    return a.name.localeCompare(b.name)
+  } else if (a.name.includes(':')) {
+    return 1
+  } else {
+    return -1
+  }
+}
+
 export function TagSelect({
   tags,
   filter,
@@ -39,7 +50,7 @@ export function TagSelect({
             )
           }
         >
-          {tags.map((x) => (
+          {tags.toSorted(sortTags).map((x) => (
             <option key={x.name} value={x.name}>
               {x.name}
             </option>
@@ -97,7 +108,7 @@ export function TagSelect({
       {isOpen && (
         <div className="absolute group-hover:visible -top-4 -left-4 p-2 z-50 text-black dark:text-[#dddddd]">
           <div className="flex flex-col gap-y-2 py-2 px-3 pr-6 bg-white dark:bg-[#292929] border-solid border-[1px] border-[#d0d0d0]/95 dark:border-[#505050] rounded-lg w-max shadow">
-            {tags.map((x) => (
+            {tags.toSorted(sortTags).map((x) => (
               <label key={x.name} className="cursor-pointer">
                 <input
                   type="checkbox"

--- a/web/graph.tsx
+++ b/web/graph.tsx
@@ -47,6 +47,9 @@ const titles: Record<string, Record<string, string | undefined> | undefined> = {
   },
   docker: {
     container: 'Container',
+    'swarm/task': 'Task',
+    'swarm/service': 'Service',
+    'swarm/namespace': 'Namespace',
   },
 }
 

--- a/web/graph.tsx
+++ b/web/graph.tsx
@@ -50,6 +50,8 @@ const titles: Record<string, Record<string, string | undefined> | undefined> = {
     'swarm/task': 'Task',
     'swarm/service': 'Service',
     'swarm/namespace': 'Namespace',
+    'compose/service': 'Service',
+    'compose/project': 'Project',
   },
 }
 

--- a/web/tags.ts
+++ b/web/tags.ts
@@ -123,10 +123,22 @@ export const TagsByName: Record<string, Tag> = Object.fromEntries(
   Tags.map((x) => [x.name, x])
 )
 
-/** Sort tags lexically, putting prefixed tags last. */
-export function sortTags(a: Tag | string, b: Tag | string): number {
-  const aString = typeof a === 'string' ? a : a.name
-  const bString = typeof b === 'string' ? b : b.name
+/** Sort tags lexically, putting prefixed tags last, selected tags first. */
+export function compareTags(
+  a: string,
+  b: string,
+  aSelected?: boolean,
+  bSelected?: boolean
+): number {
+  // Prioritize selected tags
+  if (aSelected === true && bSelected === false) {
+    return -1
+  } else if (aSelected === false && bSelected === true) {
+    return 1
+  }
+
+  const aString = typeof a === 'string' ? a : a
+  const bString = typeof b === 'string' ? b : b
 
   if (aString.includes(':') === bString.includes(':')) {
     return aString.localeCompare(bString)

--- a/web/tags.ts
+++ b/web/tags.ts
@@ -63,6 +63,16 @@ export const Tags: Tag[] = [
     color: palette.kubernetes,
   },
   {
+    name: 'service',
+    description: 'A Docker Swarm service',
+    color: palette.docker,
+  },
+  {
+    name: 'task',
+    description: 'A Docker Swarm task',
+    color: palette.docker,
+  },
+  {
     name: 'docker',
     description: 'A docker image',
     color: palette.docker,

--- a/web/tags.ts
+++ b/web/tags.ts
@@ -112,3 +112,17 @@ export const Tags: Tag[] = [
 export const TagsByName: Record<string, Tag> = Object.fromEntries(
   Tags.map((x) => [x.name, x])
 )
+
+/** Sort tags lexically, putting prefixed tags last. */
+export function sortTags(a: Tag | string, b: Tag | string): number {
+  const aString = typeof a === 'string' ? a : a.name
+  const bString = typeof b === 'string' ? b : b.name
+
+  if (aString.includes(':') === bString.includes(':')) {
+    return aString.localeCompare(bString)
+  } else if (aString.includes(':')) {
+    return 1
+  } else {
+    return -1
+  }
+}


### PR DESCRIPTION
- **Ensure no duplicate tags are created**
- **Add Kubernetes namespaces as tags**
- **Improve support for Docker Swarm and Docker Compose**
  - Identify tags even when Docker Swarm uses a digest image
  - Graph Docker Swarm and Compose tasks, services and namespaces
  - Add Docker Swarm namespaces and Docker Compose projects as a tag

Screenshot of graph in Docker Swarm:

<img width="818" alt="image" src="https://github.com/user-attachments/assets/2e0c2003-3a6a-4228-a041-cd138ab275de" />

Screenshot of image with namespace tag in Docker:

<img width="828" alt="image" src="https://github.com/user-attachments/assets/c932a883-0806-4e32-a28f-f1cfd5073cd5" />

Screenshot of image with namespace tag in Kubernetes:

<img width="824" alt="image" src="https://github.com/user-attachments/assets/a2022a0d-9965-43b1-aa58-ba7388388928" />
