### PR TITLE
Fix crash when pods are created by unsupported resource

### DIFF
--- a/cmd/cupdate/main.go
+++ b/cmd/cupdate/main.go
@@ -356,7 +356,10 @@ func main() {
 
 						if childNode != nil {
 							resource := (*childNode).(kubernetes.Resource)
-							tags = append(tags, kubernetes.TagName(resource.Kind()))
+							kind := resource.Kind()
+							if kind.IsSupported() {
+								tags = append(tags, kubernetes.TagName(resource.Kind()))
+							}
 						}
 					}
 				}

--- a/internal/platform/kubernetes/resources.go
+++ b/internal/platform/kubernetes/resources.go
@@ -18,7 +18,23 @@ const (
 	ResourceKindCoreV1Namespace   = "core/v1/namespace"
 	ResourceKindCoreV1Pod         = "core/v1/pod"
 	ResourceKindCoreV1Container   = "core/v1/container"
+	ResourceKindUnknown           = "unknown"
 )
+
+// IsSupported returns whether or not the resource is supported.
+// Filters out custom resource definitions.
+func (r ResourceKind) IsSupported() bool {
+	switch r {
+	case ResourceKindAppsV1Deployment, ResourceKindAppsV1DaemonSet,
+		ResourceKindAppsV1ReplicaSet, ResourceKindAppsV1StatefulSet,
+		ResourceKindBatchV1CronJob, ResourceKindBatchV1Job,
+		ResourceKindCoreV1Namespace, ResourceKindCoreV1Pod,
+		ResourceKindCoreV1Container:
+		return true
+	default:
+		return false
+	}
+}
 
 type Resource interface {
 	platform.Node
@@ -53,6 +69,8 @@ func (r resource) String() string {
 	return fmt.Sprintf("%s<%s>", r.kind, r.name)
 }
 
+// TagName returns the name of a tag representing the resource.
+// Panics if [ResourceKind.IsSupported] returns false.
 func TagName(kind ResourceKind) string {
 	switch kind {
 	case ResourceKindAppsV1Deployment:

--- a/internal/platform/kubernetes/utils.go
+++ b/internal/platform/kubernetes/utils.go
@@ -228,9 +228,16 @@ func addObjectToGraph(graph platform.Graph, obj runtime.Object, includeOldReplic
 			// For now, let's assume a pod only has one owning reference
 			var parent Resource
 			if len(o.OwnerReferences) > 0 {
+				kind := ResourceKind(strings.ToLower(o.OwnerReferences[0].APIVersion + "/" + o.OwnerReferences[0].Kind))
+				if !kind.IsSupported() {
+					// Even though we don't know anyhting about the resource, add it as a
+					// unknown type to show it in the UI
+					kind = ResourceKindUnknown
+				}
+
 				parent = resource{
 					id:   fmt.Sprintf("kubernetes/%s", o.OwnerReferences[0].UID),
-					kind: ResourceKind(strings.ToLower(o.OwnerReferences[0].APIVersion + "/" + o.OwnerReferences[0].Kind)),
+					kind: kind,
 					name: o.OwnerReferences[0].Name,
 				}
 			}

--- a/web/graph.tsx
+++ b/web/graph.tsx
@@ -43,6 +43,7 @@ const titles: Record<string, Record<string, string | undefined> | undefined> = {
     'batch/v1/job': 'Job',
     'batch/v1/cronjob': 'Cron job',
     'apps/v1/statefulset': 'Stateful set',
+    unknown: '<unknown resource>',
   },
   docker: {
     container: 'Container',


### PR DESCRIPTION
When Cupdate find a running pod it tries to identify its parent
resource, assuming that it's created by one of the watched resouce
types. When CRDs (or v1/Nodes) are in use, that's not always true.

Fix this issue by introducing an unknown kind used for non-allow-listed
resource types.

Solves: #54
