### PR TITLE
Add an API endpoint to get the summary

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -176,6 +176,17 @@ paths:
           content:
             application/rss+xml:
 
+  /summary:
+    get:
+      summary: Get a summary.
+      responses:
+        "200":
+          description: Summary
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Summary"
+
 components:
   schemas:
     ImagePage:
@@ -186,25 +197,7 @@ components:
           items:
             $ref: "#/components/schemas/Image"
         summary:
-          type: object
-          properties:
-            images:
-              description: Total number of images
-              type: number
-            outdated:
-              description: Total number of outdated images
-              type: number
-            vulnerable:
-              description: Total number of vulnerable images
-              type: number
-            processing:
-              description: Total number of unprocessed images
-              type: number
-          required:
-            - images
-            - outdated
-            - vulnerable
-            - processing
+          $ref: "#/components/schemas/Summary"
         pagination:
           $ref: "#/components/schemas/PaginationMetadata"
       required:
@@ -384,3 +377,24 @@ components:
         type:
           type: string
           enum: ["imageUpdated"]
+
+    Summary:
+      type: object
+      properties:
+        images:
+          description: Total number of images
+          type: number
+        outdated:
+          description: Total number of outdated images
+          type: number
+        vulnerable:
+          description: Total number of vulnerable images
+          type: number
+        processing:
+          description: Total number of unprocessed images
+          type: number
+      required:
+        - images
+        - outdated
+        - vulnerable
+        - processing

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -300,6 +300,14 @@ func NewServer(api *store.Store, hub *events.Hub[store.Event], processQueue chan
 		}
 	})
 
+	s.mux.HandleFunc("GET /api/v1/summary", func(w http.ResponseWriter, r *http.Request) {
+		ctx, span := httputil.SpanFromRequest(r)
+		span.SetAttributes(semconv.HTTPRoute("/api/v1/summary"))
+
+		response, err := api.Summary(ctx)
+		s.handleJSONResponse(w, r, response, err)
+	})
+
 	return s
 }
 


### PR DESCRIPTION
Break out the image page summary to a separate function and expose the
reused functionality under /api/v1/summary. The data is exactly the same
as the summary retrieved through /api/v1/images.

Solves: #64
