### PR TITLE
Improve UI support for digests

### DIFF
--- a/web/components/ImageCard.tsx
+++ b/web/components/ImageCard.tsx
@@ -50,18 +50,27 @@ export function ImageCard({
             )}
           </div>
           <div className="flex flex-row items-center gap-x-2">
+            {/* Digests are formatted like <algo>:<digest>, such as sha256:<digest>. Show a maximum of 5 hex digits before truncating with ellipsis (hence 15ch) */}
             {latestVersion ? (
               currentVersion === latestVersion ? (
-                <p className="text-green-600">{latestVersion}</p>
+                <p className="text-green-600 max-w-[15ch] truncate">
+                  {latestVersion}
+                </p>
               ) : (
                 <>
-                  <p className="text-red-600 line-through">{currentVersion}</p>
-                  <p className="text-green-600">{latestVersion}</p>
+                  <p className="text-red-600 line-through max-w-[15ch] truncate">
+                    {currentVersion}
+                  </p>
+                  <p className="text-green-600 max-w-[15ch] truncate">
+                    {latestVersion}
+                  </p>
                 </>
               )
             ) : (
               <>
-                <p className="text-yellow-600">{currentVersion}</p>
+                <p className="text-yellow-600 max-w-[15ch] truncate">
+                  {currentVersion}
+                </p>
                 {!latestVersion && (
                   <InfoTooltip
                     icon={<FluentWarning16Filled className="text-yellow-600" />}

--- a/web/oci.ts
+++ b/web/oci.ts
@@ -1,11 +1,41 @@
+function parse(reference: string): {
+  name: string
+  tag: string
+  digest: string
+} {
+  let digest = ''
+  const digestDelimiter = reference.indexOf('@')
+  if (digestDelimiter >= 0) {
+    digest = reference.substring(digestDelimiter + 1)
+    reference = reference.substring(0, digestDelimiter)
+  }
+
+  let tag = ''
+  const tagDelimiter = reference.indexOf(':')
+  if (tagDelimiter >= 0) {
+    digest = reference.substring(tagDelimiter + 1)
+    tag = reference.substring(0, tagDelimiter)
+  }
+
+  return {
+    name: reference,
+    tag,
+    digest,
+  }
+}
+
 export function version(reference: string): string {
-  const parts = reference.split(':')
-  if (parts.length === 1) {
+  const { tag, digest } = parse(reference)
+  if (digest.length > 0) {
+    return digest
+  } else if (tag.length > 0) {
+    return tag
+  } else {
     return 'latest'
   }
-  return parts[1]
 }
+
 export function name(reference: string): string {
-  const parts = reference.split(':')
-  return parts[0]
+  const { name } = parse(reference)
+  return name
 }

--- a/web/pages/ImagePage.tsx
+++ b/web/pages/ImagePage.tsx
@@ -177,10 +177,13 @@ export function ImagePage(): JSX.Element {
         )}
       </h1>
       {/* Image version */}
+      {/* Digests are formatted like <algo>:<digest>, such as sha256:<digest>. Show a maximum of 5 hex digits before truncating with ellipsis (hence 15ch) */}
       <div className="flex items-center">
         {!image.value.latestReference ? (
-          <p className="font-medium">
-            {version(image.value.reference)}{' '}
+          <>
+            <p className="font-medium max-w-[15ch] truncate">
+              {version(image.value.reference)}{' '}
+            </p>
             <InfoTooltip
               icon={<FluentWarning16Filled className="text-yellow-600" />}
             >
@@ -188,16 +191,18 @@ export function ImagePage(): JSX.Element {
               image not being available, the registry not being supported,
               missing authentication or a temporary issue.
             </InfoTooltip>
-          </p>
+          </>
         ) : image.value.reference === image.value.latestReference ? (
-          <p className="font-medium">{version(image.value.reference)}</p>
+          <p className="font-medium max-w-[15ch] truncate">
+            {version(image.value.reference)}
+          </p>
         ) : (
           <>
             <FluentChevronDown20Regular className="text-red-600" />
-            <p className="font-medium text-red-600">
+            <p className="font-medium text-red-600 max-w-[15ch] truncate">
               {version(image.value.reference)}
             </p>
-            <p className="font-medium ml-4 text-green-600">
+            <p className="font-medium ml-4 text-green-600 max-w-[15ch] truncate">
               {image.value.latestReference
                 ? version(image.value.latestReference)
                 : 'unknown'}


### PR DESCRIPTION
Digests were not gracefully rendered in the UI. Improve the support of
showing such images.

Truncate image tags to 15 roughly characters to render at most five hex
digits of a typical digest. Regular tags are subject to the same limit
but are unlikely to come near.

![image](https://github.com/user-attachments/assets/5ed2183c-6fe9-4a46-9672-dc54b6cc1b33)

![image](https://github.com/user-attachments/assets/c990e759-5662-4770-b5fb-1aed529b5810)
