### PR TITLE
Add support for  custom registries, registry auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /*.sqlite*
 /*.boltdb
 /docker.sock
+/integration/zot/htpasswd

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,3 +129,31 @@ as the Docker host rather then the one specified in `.env-docker`.
 ```shell
 go run tools/sockproxy/*.go -p 3000 docker.sock
 ```
+
+### Testing custom registry
+
+To test custom registries and authentication, Zot can be used.
+
+```shell
+# Create a htpasswd for zot
+htpasswd -bBn username password > integration/zot/htpasswd
+```
+
+```shell
+docker run --rm -it -p 9090:9090 --volume "$PWD/integration/zot:/etc/zot:ro" ghcr.io/project-zot/zot-linux-arm64
+```
+
+Note that Zot's UI doesn't work on Safari ATM - you will just be logged out if
+you log in.
+
+Run an image using zot instead.
+
+```shell
+docker run --rm -it localhost:9090/alpine
+```
+
+Start Cupdate targeting Docker, specifying the auth file.
+
+```shell
+export CUPDATE_REGISTRY_SECRETS="integration/zot/docker-basic-auth.json"
+```

--- a/docs/config.md
+++ b/docs/config.md
@@ -29,3 +29,4 @@ done using environment variables.
 | `CUPDATE_DOCKER_INCLUDE_ALL_CONTAINERS`   | Whether or not to include containers in any state, not just running containers.                                                                         | `false`                         |
 | `CUPDATE_OTEL_TARGET`                     | Target URL to an Open Telemetry GRPC ingest endpoint.                                                                                                   | Required to use Open Telemetry. |
 | `CUPDATE_OTEL_INSECURE`                   | Disable client transport security for the Open Telemetry GRPC connection.                                                                               | `false`                         |
+| `CUPDATE_REGISTRY_SECRETS`                | Path to a JSON file containing registry secrets. See Docker's config.json and Kubernetes' `imagePullSecrets`.                                           | None                            |

--- a/integration/zot/config.json
+++ b/integration/zot/config.json
@@ -1,0 +1,30 @@
+{
+  "distSpecVersion": "1.0.1",
+  "storage": {
+    "rootDirectory": "/tmp/zot/storage"
+  },
+  "log": {
+    "level": "debug"
+  },
+  "http": {
+    "address": "0.0.0.0",
+    "port": "9090",
+    "auth": {
+      "htpasswd": {
+        "path": "/etc/zot/htpasswd"
+      },
+      "apikey": true
+    }
+  },
+  "extensions": {
+    "sync": {
+      "enable": true,
+      "registries": [
+        {
+          "urls": ["https://docker.io/library"],
+          "onDemand": true
+        }
+      ]
+    }
+  }
+}

--- a/integration/zot/docker-basic-auth.json
+++ b/integration/zot/docker-basic-auth.json
@@ -1,0 +1,8 @@
+{
+  "auths": {
+    "http://localhost:9090/v2/": {
+      "username": "username",
+      "password": "password"
+    }
+  }
+}

--- a/internal/dockerhub/client_test.go
+++ b/internal/dockerhub/client_test.go
@@ -30,8 +30,8 @@ func TestClientGetManifest(t *testing.T) {
 	require.NoError(t, err)
 
 	ociClient := &oci.Client{
-		Client:     client.Client,
-		Authorizer: client,
+		Client:   client.Client,
+		AuthFunc: client.HandleAuth,
 	}
 
 	actual, err := ociClient.GetManifests(context.TODO(), ref)
@@ -53,8 +53,8 @@ func TestClientGetAnnotations(t *testing.T) {
 	require.NoError(t, err)
 
 	ociClient := &oci.Client{
-		Client:     client.Client,
-		Authorizer: client,
+		Client:   client.Client,
+		AuthFunc: client.HandleAuth,
 	}
 
 	manifests, err := ociClient.GetAnnotations(context.TODO(), ref, nil)
@@ -105,7 +105,10 @@ func TestGetTags(t *testing.T) {
 		Client: httputil.NewClient(cachetest.NewCache(t), 24*time.Hour),
 	}
 
-	ociClient := oci.Client{Client: client.Client, Authorizer: client}
+	ociClient := oci.Client{
+		Client:   client.Client,
+		AuthFunc: client.HandleAuth,
+	}
 
 	ref, err := oci.ParseReference("mongo")
 	require.NoError(t, err)

--- a/internal/ghcr/client_test.go
+++ b/internal/ghcr/client_test.go
@@ -28,8 +28,8 @@ func TestClientGetManifest(t *testing.T) {
 	require.NoError(t, err)
 
 	ociClient := &oci.Client{
-		Client:     client.Client,
-		Authorizer: client,
+		Client:   client.Client,
+		AuthFunc: client.HandleAuth,
 	}
 
 	actual, err := ociClient.GetManifests(context.TODO(), ref)
@@ -51,8 +51,8 @@ func TestClientGetAnnotations(t *testing.T) {
 	require.NoError(t, err)
 
 	ociClient := &oci.Client{
-		Client:     client.Client,
-		Authorizer: client,
+		Client:   client.Client,
+		AuthFunc: client.HandleAuth,
 	}
 
 	manifests, err := ociClient.GetAnnotations(context.TODO(), ref, nil)

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -160,7 +160,9 @@ func parsePackage(r io.Reader, owner string) (*Package, error) {
 
 	hrefs := make([]string, 0)
 	match(node, func(node *html.Node) bool {
-		if node.Data == "a" && strings.HasPrefix(attr(node, "href"), fmt.Sprintf("/users/%s/packages/container/", owner)) {
+		matchesUserHref := strings.HasPrefix(attr(node, "href"), fmt.Sprintf("/users/%s/packages/container/", owner))
+		matchesOrgHref := strings.HasPrefix(attr(node, "href"), fmt.Sprintf("/orgs/%s/packages/container/", owner))
+		if node.Data == "a" && (matchesUserHref || matchesOrgHref) {
 			hrefs = append(hrefs, attr(node, "href"))
 		}
 		return false

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -43,7 +43,7 @@ func TestClientGetDescription(t *testing.T) {
 	fmt.Printf("%+v\n", release)
 }
 
-func TestClientGetPackage(t *testing.T) {
+func TestClientGetUserPackage(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -57,8 +57,24 @@ func TestClientGetPackage(t *testing.T) {
 
 	release, err := c.GetPackage(context.TODO(), ref)
 	require.NoError(t, err)
+	assert.NotNil(t, release)
+}
 
-	fmt.Printf("%+v\n", release)
+func TestClientGetOrgPackage(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	c := &Client{
+		Client: httputil.NewClient(cachetest.NewCache(t), 24*time.Hour),
+	}
+
+	ref, err := oci.ParseReference("ghcr.io/project-zot/zot-linux-arm64")
+	require.NoError(t, err)
+
+	release, err := c.GetPackage(context.TODO(), ref)
+	require.NoError(t, err)
+	assert.NotNil(t, release)
 }
 
 func TestClientGetREADME(t *testing.T) {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/AlexGustafsson/cupdate/internal/cachetest"
 	"github.com/AlexGustafsson/cupdate/internal/httputil"
 	"github.com/AlexGustafsson/cupdate/internal/oci"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/gitlab/client.go
+++ b/internal/gitlab/client.go
@@ -17,8 +17,6 @@ import (
 
 var readmePathRegexp = regexp.MustCompile(`href="(.*?/blob/.*?)"`)
 
-var _ oci.Authorizer = (*Client)(nil)
-
 type Client struct {
 	Client *httputil.Client
 }
@@ -168,7 +166,7 @@ func (c *Client) GetBlob(ctx context.Context, href string, includeRaw bool) (*Bl
 	return &blob, nil
 }
 
-func (c *Client) GetRegistryToken(ctx context.Context, image oci.Reference) (string, error) {
+func (c *Client) GetRegistryToken(ctx context.Context, repository string) (string, error) {
 	// TODO: Registries expose the realm and scheme via Www-Authenticate if 403
 	// is given
 	u, err := url.Parse("https://gitlab.com/jwt/auth?service=container_registry")
@@ -177,7 +175,7 @@ func (c *Client) GetRegistryToken(ctx context.Context, image oci.Reference) (str
 	}
 
 	query := u.Query()
-	query.Set("scope", fmt.Sprintf("repository:%s:pull", image.Path))
+	query.Set("scope", fmt.Sprintf("repository:%s:pull", repository))
 	u.RawQuery = query.Encode()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
@@ -207,13 +205,20 @@ func (c *Client) GetRegistryToken(ctx context.Context, image oci.Reference) (str
 	return result.Token, nil
 }
 
-func (c *Client) AuthorizeOCIRequest(ctx context.Context, image oci.Reference, req *http.Request) error {
-	token, err := c.GetRegistryToken(ctx, image)
+func (c *Client) HandleAuth(r *http.Request) error {
+	name := oci.NameFromAPI(r.URL.Path)
+	if r.Host != "registry.gitlab.com" || name == "" {
+		return nil
+	}
+
+	token, err := c.GetRegistryToken(r.Context(), name)
 	if err != nil {
 		return err
 	}
 
-	return oci.AuthorizerToken(token).AuthorizeOCIRequest(ctx, image, req)
+	r.Header.Set("Authorization", "Bearer "+token)
+
+	return nil
 }
 
 func (c *Client) GetProjectContainerRepositories(ctx context.Context, fullPath string) ([]ContainerRepository, error) {

--- a/internal/gitlab/client_test.go
+++ b/internal/gitlab/client_test.go
@@ -8,8 +8,35 @@ import (
 
 	"github.com/AlexGustafsson/cupdate/internal/cachetest"
 	"github.com/AlexGustafsson/cupdate/internal/httputil"
+	"github.com/AlexGustafsson/cupdate/internal/oci"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestClientGetManifest(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	expected := &oci.Manifest{}
+
+	client := &Client{
+		Client: httputil.NewClient(cachetest.NewCache(t), 24*time.Hour),
+	}
+
+	ref, err := oci.ParseReference("registry.gitlab.com/arm-research/smarter/smarter-device-manager")
+	require.NoError(t, err)
+
+	ociClient := &oci.Client{
+		Client:   client.Client,
+		AuthFunc: client.HandleAuth,
+	}
+
+	actual, err := ociClient.GetManifests(context.TODO(), ref)
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, actual)
+}
 
 func TestGetRepositoryDescription(t *testing.T) {
 	if testing.Short() {

--- a/internal/httputil/auth.go
+++ b/internal/httputil/auth.go
@@ -1,0 +1,193 @@
+package httputil
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+)
+
+type AuthHandler interface {
+	HandleAuth(*http.Request) error
+}
+
+type AuthHandlerFunc func(*http.Request) error
+
+func (f AuthHandlerFunc) HandleAuth(r *http.Request) error {
+	return f(r)
+}
+
+var _ AuthHandler = (*BasicAuthHandler)(nil)
+
+type BasicAuthHandler struct {
+	Username string
+	Password string
+}
+
+func (h BasicAuthHandler) HandleAuth(r *http.Request) error {
+	credentials := base64.StdEncoding.EncodeToString([]byte(h.Username + ":" + h.Password))
+	r.Header.Set("Authorization", "Basic "+credentials)
+
+	return nil
+}
+
+type BearerToken string
+
+func (t BearerToken) HandleAuth(r *http.Request) error {
+	r.Header.Set("Authorization", "Bearer "+string(t))
+
+	return nil
+}
+
+type AuthMux struct {
+	mutex    sync.RWMutex
+	patterns map[string]AuthHandler
+	header   http.Header
+}
+
+func NewAuthMux() *AuthMux {
+	return &AuthMux{
+		patterns: make(map[string]AuthHandler),
+		header:   make(http.Header),
+	}
+}
+
+func (a *AuthMux) Handle(pattern string, handler AuthHandler) {
+	a.register(pattern, handler)
+}
+
+func (a *AuthMux) HandleFunc(pattern string, handler func(*http.Request) error) {
+	a.register(pattern, AuthHandlerFunc(handler))
+}
+
+func (a *AuthMux) HandleAuth(r *http.Request) error {
+	a.mutex.RLock()
+
+	handler := a.match(r.URL)
+	if handler == nil {
+		handler = a.patterns[""]
+	}
+
+	for k, v := range a.header {
+		r.Header[k] = v
+	}
+
+	a.mutex.RUnlock()
+
+	if handler == nil {
+		return nil
+	}
+
+	return handler.HandleAuth(r)
+}
+
+func (a *AuthMux) SetHeader(key string, value string) {
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+
+	a.header.Set(key, value)
+}
+
+func (a *AuthMux) register(pattern string, handler AuthHandler) {
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+
+	a.patterns[pattern] = handler
+}
+
+func (a *AuthMux) match(url *url.URL) AuthHandler {
+	// TODO: This code is not especially nice or efficient. For example, it parses
+	// the URLs every iteration
+	for pattern, handler := range a.patterns {
+		if pattern == "" {
+			continue
+		}
+
+		// Compare scheme, if set in pattern - otherwise allow any scheme
+		if !strings.HasPrefix(pattern, "https://") && !strings.HasPrefix(pattern, "http://") {
+			pattern = url.Scheme + "://" + pattern
+		}
+
+		u, err := url.Parse(pattern)
+		if err != nil {
+			continue
+		}
+
+		if url.Scheme != u.Scheme {
+			continue
+		}
+
+		// The Docker client matches either the image or hostname, where the API can
+		// have a /v2/ or /v1/ prefix
+		if strings.HasPrefix(u.Path, "/v2/") || strings.HasPrefix(u.Path, "/v1/") {
+			u.Path = u.Path[3:]
+		}
+
+		// If the pattern has a path specified, match it
+		if u.Path != "" && u.Path != "/" {
+			p := url.Path
+			if !strings.HasSuffix(p, "/") {
+				p += "/"
+			}
+
+			// Make sure paths in patterns match full segments
+			if !strings.HasSuffix(u.Path, "/") {
+				u.Path += "/"
+			}
+
+			if !strings.HasPrefix(p, u.Path) {
+				continue
+			}
+		}
+
+		urlParts := strings.Split(url.Host, ".")
+		patternParts := strings.Split(u.Host, ".")
+
+		// The pattern has more parts of its hostname than the URL
+		if len(urlParts) < len(patternParts) {
+			continue
+		}
+
+		matched := true
+		for i := 0; i < len(patternParts); i++ {
+			if strings.HasPrefix(patternParts[i], "*") {
+				if !strings.HasSuffix(urlParts[i], patternParts[i][1:]) {
+					matched = false
+					break
+				}
+			} else if strings.HasSuffix(patternParts[i], "*") {
+				// TODO:
+			} else if urlParts[i] != patternParts[i] {
+				matched = false
+				break
+			}
+		}
+
+		if matched {
+			return handler
+		}
+	}
+
+	return nil
+}
+
+func (a *AuthMux) Copy(other *AuthMux) {
+	if other == nil {
+		return
+	}
+
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+
+	other.mutex.RLock()
+	defer other.mutex.RUnlock()
+
+	for pattern, handler := range other.patterns {
+		a.patterns[pattern] = handler
+	}
+
+	for k, v := range other.header {
+		a.header[k] = v
+	}
+}

--- a/internal/httputil/auth_test.go
+++ b/internal/httputil/auth_test.go
@@ -1,0 +1,209 @@
+package httputil
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+var _ AuthHandler = (*MockAuthHandler)(nil)
+
+type MockAuthHandler struct {
+	mock.Mock
+}
+
+// HandleAuth implements AuthHandler.
+func (m *MockAuthHandler) HandleAuth(r *http.Request) error {
+	args := m.Called(r)
+	return args.Error(0)
+}
+
+func TestAuthMuxPatterns(t *testing.T) {
+	testCases := []struct {
+		Pattern  string
+		URL      string
+		Expected bool
+	}{
+		// From: https://kubernetes.io/docs/concepts/containers/images/#config-json
+		{
+			Pattern:  "*.kubernetes.io",
+			URL:      "https://abc.kubernetes.io",
+			Expected: true,
+		},
+		{
+			Pattern:  "*.kubernetes.io",
+			URL:      "https://kubernetes.io",
+			Expected: false,
+		},
+		{
+			Pattern:  "*.*.kubernetes.io",
+			URL:      "https://abc.kubernetes.io",
+			Expected: false,
+		},
+		{
+			Pattern:  "*.*.kubernetes.io",
+			URL:      "https://abc.def.kubernetes.io",
+			Expected: true,
+		},
+		{
+			Pattern:  "prefix.*.io",
+			URL:      "https://prefix.kubernetes.io",
+			Expected: true,
+		},
+		{
+			Pattern:  "*-good.kubernetes.io",
+			URL:      "https://prefix-good.kubernetes.io",
+			Expected: true,
+		},
+		{
+			Pattern:  "my-registry.io/images",
+			URL:      "https://my-registry.io/images",
+			Expected: true,
+		},
+		{
+			Pattern:  "my-registry.io/images",
+			URL:      "https://my-registry.io/images/my-image",
+			Expected: true,
+		},
+		{
+			Pattern:  "my-registry.io/images",
+			URL:      "https://my-registry.io/images/another-image",
+			Expected: true,
+		},
+		{
+			Pattern:  "*.my-registry.io/images",
+			URL:      "https://sub.my-registry.io/images/my-image",
+			Expected: true,
+		},
+		{
+			Pattern:  "*.my-registry.io/images",
+			URL:      "https://a.sub.my-registry.io/images/my-image",
+			Expected: false,
+		},
+		{
+			Pattern:  "*.my-registry.io/images",
+			URL:      "https://a.b.sub.my-registry.io/images/my-image",
+			Expected: false,
+		},
+		{
+			Pattern:  "my-registry.io/images",
+			URL:      "https://a.sub.my-registry.io/images/my-image",
+			Expected: false,
+		},
+		{
+			Pattern:  "my-registry.io/images",
+			URL:      "https://a.b.sub.my-registry.io/images/my-image",
+			Expected: false,
+		},
+		// HTTP / HTTPS
+		{
+			Pattern:  "https://example.com",
+			URL:      "https://example.com/images",
+			Expected: true,
+		},
+		{
+			Pattern:  "https://example.com",
+			URL:      "http://example.com/images",
+			Expected: false,
+		},
+		{
+			Pattern:  "example.com",
+			URL:      "https://example.com/images",
+			Expected: true,
+		},
+		{
+			Pattern:  "example.com",
+			URL:      "http://example.com/images",
+			Expected: true,
+		},
+		// IP / port
+		{
+			Pattern:  "example.com:8080",
+			URL:      "https://example.com:8080/alpine",
+			Expected: true,
+		},
+		{
+			Pattern:  "192.168.1.100:8080",
+			URL:      "https://192.168.1.100:8080/alpine",
+			Expected: true,
+		},
+		{
+			Pattern:  "192.168.1.100",
+			URL:      "https://192.168.1.100/alpine",
+			Expected: true,
+		},
+		{
+			Pattern:  "example.com",
+			URL:      "https://example.com:8080/alpine",
+			Expected: false,
+		},
+		{
+			Pattern:  "192.168.1.100",
+			URL:      "https://192.168.1.100:8080/alpine",
+			Expected: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(fmt.Sprintf("%s matches %s: %v", testCase.Pattern, testCase.URL, testCase.Expected), func(t *testing.T) {
+			authMux := NewAuthMux()
+
+			handler := &MockAuthHandler{}
+			handler.On("HandleAuth", mock.Anything).Return(nil)
+
+			if testCase.Expected {
+				authMux.Handle(testCase.Pattern, handler)
+			} else {
+				// Register default handler to test that no handler was matched
+				authMux.Handle("", handler)
+			}
+
+			req, err := http.NewRequest(http.MethodGet, testCase.URL, nil)
+			require.NoError(t, err)
+
+			err = authMux.HandleAuth(req)
+			require.NoError(t, err)
+
+			handler.AssertExpectations(t)
+		})
+	}
+}
+
+func TestAuthMuxModifiesRequest(t *testing.T) {
+	authMux := NewAuthMux()
+
+	handler := &MockAuthHandler{}
+	handler.On("HandleAuth", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		args.Get(0).(*http.Request).Header.Set("Authorization", "Bearer <token>")
+	})
+
+	authMux.Handle("", handler)
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+
+	err = authMux.HandleAuth(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Bearer <token>", req.Header.Get("Authorization"))
+
+	handler.AssertExpectations(t)
+}
+
+func TestAuthMuxSetsHeaders(t *testing.T) {
+	authMux := NewAuthMux()
+
+	authMux.SetHeader("Authorization", "Bearer <token>")
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+
+	err = authMux.HandleAuth(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Bearer <token>", req.Header.Get("Authorization"))
+}

--- a/internal/oci/util.go
+++ b/internal/oci/util.go
@@ -1,0 +1,31 @@
+package oci
+
+import "strings"
+
+// NameFromAPI returns the OCI name based on the distribution spec API endpoint.
+// Assumes name has at least two components.
+// SEE: https://github.com/opencontainers/distribution-spec/blob/main/spec.md#endpoints
+func NameFromAPI(path string) string {
+	// /v2/<name>/[blobs,manifests,tags,referrers
+	parts := strings.Split(path, "/")
+	if len(parts) < 4 {
+		return ""
+	}
+
+	if parts[0] != "" || parts[1] != "v2" {
+		return ""
+	}
+
+	components := 2
+loop:
+	for i := 4; i < len(parts); i++ {
+		switch parts[i] {
+		case "blobs", "manifests", "tags", "referrers":
+			break loop
+		default:
+			components++
+		}
+	}
+
+	return strings.Join(parts[2:2+components], "/")
+}

--- a/internal/oci/util_test.go
+++ b/internal/oci/util_test.go
@@ -1,0 +1,55 @@
+package oci
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNameFromAPI(t *testing.T) {
+	testCases := []struct {
+		Path     string
+		Expected string
+	}{
+		{
+			Path:     "/v2/arm-research/smarter/smarter-device-manager/tags/list",
+			Expected: "arm-research/smarter/smarter-device-manager",
+		},
+		{
+			Path:     "/v2/alexgustafsson/cupdate/vulndb/tags/list",
+			Expected: "alexgustafsson/cupdate/vulndb",
+		},
+		{
+			// Blobs OK in name
+			Path:     "/v2/test/blobs/blobs/ref",
+			Expected: "test/blobs",
+		},
+		{
+			// Empty
+			Path:     "",
+			Expected: "",
+		},
+		{
+			// Too few path segments
+			Path:     "/",
+			Expected: "",
+		},
+		{
+			// Too few path segments
+			Path:     "/v2",
+			Expected: "",
+		},
+		{
+			// Invalid path
+			Path:     "v2/alexgustafsson/cupdate/vulndb/tags/list",
+			Expected: "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Path, func(t *testing.T) {
+			actual := NameFromAPI(testCase.Path)
+			assert.Equal(t, testCase.Expected, actual)
+		})
+	}
+}

--- a/internal/platform/docker/config.go
+++ b/internal/platform/docker/config.go
@@ -1,0 +1,13 @@
+package docker
+
+type ConfigFile struct {
+	Auths       map[string]ConfigEntry `json:"auths"`
+	HttpHeaders map[string]string      `json:"HttpHeaders,omitempty"`
+}
+
+type ConfigEntry struct {
+	Auth     string `json:"auth,omitempty"`
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+	Email    string `json:"email,omitempty"`
+}

--- a/internal/vulndb/fetch.go
+++ b/internal/vulndb/fetch.go
@@ -21,9 +21,9 @@ func Fetch(ctx context.Context, httpClient *httputil.Client, destination string)
 
 	client := oci.Client{
 		Client: httpClient,
-		Authorizer: &ghcr.Client{
+		AuthFunc: (&ghcr.Client{
 			Client: httpClient,
-		},
+		}).HandleAuth,
 	}
 
 	ref, err := oci.ParseReference("ghcr.io/alexgustafsson/cupdate/vulndb:latest")

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -19,18 +19,20 @@ import (
 var _ prometheus.Collector = (*Worker)(nil)
 
 type Worker struct {
-	httpClient *httputil.Client
-	store      *store.Store
+	httpClient   *httputil.Client
+	store        *store.Store
+	registryAuth *httputil.AuthMux
 
 	processedCounter   prometheus.Counter
 	processingDuration prometheus.Counter
 	processingGauge    prometheus.Gauge
 }
 
-func New(httpClient *httputil.Client, store *store.Store) *Worker {
+func New(httpClient *httputil.Client, store *store.Store, registryAuth *httputil.AuthMux) *Worker {
 	return &Worker{
-		httpClient: httpClient,
-		store:      store,
+		httpClient:   httpClient,
+		store:        store,
+		registryAuth: registryAuth,
 
 		processedCounter: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: "cupdate",
@@ -89,6 +91,7 @@ func (w *Worker) ProcessRawImage(ctx context.Context, reference oci.Reference) e
 		Links:           make([]models.ImageLink, 0),
 		Vulnerabilities: make([]models.ImageVulnerability, 0),
 		Graph:           image.Graph,
+		RegistryAuth:    w.registryAuth,
 	}
 
 	for _, tag := range image.Tags {

--- a/internal/workflow/imageworkflow/data.go
+++ b/internal/workflow/imageworkflow/data.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/AlexGustafsson/cupdate/internal/httputil"
 	"github.com/AlexGustafsson/cupdate/internal/models"
 	"github.com/AlexGustafsson/cupdate/internal/oci"
 )
@@ -23,6 +24,7 @@ type Data struct {
 	Links           []models.ImageLink
 	Vulnerabilities []models.ImageVulnerability
 	Graph           models.Graph
+	RegistryAuth    *httputil.AuthMux
 }
 
 func (d *Data) InsertTag(tag string) {

--- a/internal/workflow/imageworkflow/workflow.go
+++ b/internal/workflow/imageworkflow/workflow.go
@@ -25,7 +25,8 @@ func New(httpClient *httputil.Client, data *Data) workflow.Workflow {
 					SetupRegistryClient().
 						WithID("registry").
 						With("httpClient", httpClient).
-						With("reference", data.ImageReference),
+						With("reference", data.ImageReference).
+						With("registryAuth", data.RegistryAuth),
 					GetManifests().
 						WithID("manifests").
 						With("registryClient", workflow.Ref{Key: "step.registry.client"}).


### PR DESCRIPTION
Add support for custom registries, registry auth

Add auth support for registries through a config file with the same
format as used by Docker and Kubernetes. The implementation uses the
existing auth implementations for select registries as fallback,
assuming all other repositories allow anonymous access or that auth is
configured.

For now, there's only partial support for HTTP-based registries as there
is no nice way to configure what registries use HTTP. Additional work
could look at how the Docker CLI handles this.

With this change, images with IPs (IPv4 or IPv6) in their name should be
supported. There's currently only partial support for such images in the
UI.