### PR TITLE
Fix tags being shown in the image name

### DIFF
--- a/web/oci.ts
+++ b/web/oci.ts
@@ -13,8 +13,8 @@ function parse(reference: string): {
   let tag = ''
   const tagDelimiter = reference.indexOf(':')
   if (tagDelimiter >= 0) {
-    digest = reference.substring(tagDelimiter + 1)
-    tag = reference.substring(0, tagDelimiter)
+    tag = reference.substring(tagDelimiter + 1)
+    reference = reference.substring(0, tagDelimiter)
   }
 
   return {


### PR DESCRIPTION
After:
<img width="833" alt="image" src="https://github.com/user-attachments/assets/5dd342ac-2cf9-479f-9057-7dfba6e76232" />

Before:
<img width="837" alt="image" src="https://github.com/user-attachments/assets/8a9bff49-7f80-4e68-9138-b8e42bbe3996" />