### PR TITLE
Improve intuitiveness of search queries

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1105,5 +1105,7 @@ func (s *Store) Close() error {
 // It is not a security feature, it just ensures that all searches are full text
 // and not using fts' query syntax.
 func ftsEscape(s string) string {
-	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+	// The trailing * makes this a prefix search which will allow more natural
+	// matches on smaller queries
+	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"*`
 }


### PR DESCRIPTION
Cupdate uses sqlite's FTS to power the search queries. As the FTS syntax
is not what a typical user would expect in Cupdate's context, we only
use text matches. This change makes sure that smaller queries will also
match the expected images by allowing prefix matches, not only full word
matches.

Solves: #53
