### PR TITLE
Fix homepage widget fields

### DIFF
--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -79,13 +79,13 @@ gethomepage.dev/widget.type: customapi
 gethomepage.dev/widget.url: http://cupdate.cupdate.svc.cluster.local/api/v1/summary
 gethomepage.dev/widget.method: GET
 gethomepage.dev/widget.mappings.0.label: outdated
-gethomepage.dev/widget.mappings.0.field.summary: outdated
+gethomepage.dev/widget.mappings.0.field: outdated
 gethomepage.dev/widget.mappings.1.label: images
-gethomepage.dev/widget.mappings.1.field.summary: images
+gethomepage.dev/widget.mappings.1.field: images
 gethomepage.dev/widget.mappings.2.label: vulnerable
-gethomepage.dev/widget.mappings.2.field.summary: vulnerable
+gethomepage.dev/widget.mappings.2.field: vulnerable
 gethomepage.dev/widget.mappings.3.label: processing
-gethomepage.dev/widget.mappings.3.field.summary: processing
+gethomepage.dev/widget.mappings.3.field: processing
 ```
 
 The same support exists in Docker, but looks a little bit different:
@@ -105,12 +105,12 @@ labels:
   - homepage.widget.url=http://cupdate.internal/api/v1/summary
   - homepage.widget.method=GET
   - homepage.widget.mappings[0].label=outdated
-  - homepage.widget.mappings[0].field.summary=outdated
+  - homepage.widget.mappings[0].field=outdated
   - homepage.widget.mappings[1].label=images
-  - homepage.widget.mappings[1].field.summary=images
+  - homepage.widget.mappings[1].field=images
   - homepage.widget.mappings[2].label=vulnerable
-  - homepage.widget.mappings[2].field.summary=vulnerable
+  - homepage.widget.mappings[2].field=vulnerable
   - homepage.widget.mappings[3].label=processing
-  - homepage.widget.mappings[3].field.summary=processing
+  - homepage.widget.mappings[3].field=processing
 ``
 ```


### PR DESCRIPTION
The examples in the cookbook specify the fields paths as `summary.<field>` but the `summary` prefix was only needed when using the `/api/v1/images` endpoint. With the separate `/api/v1/summary` endpoint you no longer have the nested structure with `summary` as top-level JSON key.

I'm currently using it on my homepage and it works with this config:

```yaml
      homepage.widget.type: customapi
      homepage.widget.name: Cupdate
      homepage.widget.url: 'https://cupdate.{{HOMEPAGE_VAR_DOMAIN}}/api/v1/summary'
      homepage.widget.mappings[0].label: Images
      homepage.widget.mappings[0].field: images
      homepage.widget.mappings[0].format: number
      homepage.widget.mappings[1].label: Outdated
      homepage.widget.mappings[1].field: outdated
      homepage.widget.mappings[1].format: number
      homepage.widget.mappings[2].label: Vulnerable
      homepage.widget.mappings[2].field: vulnerable
      homepage.widget.mappings[2].format: number
      homepage.widget.mappings[3].label: Processing
      homepage.widget.mappings[3].field: processing
      homepage.widget.mappings[3].format: number
```

<img width="885" alt="image" src="https://github.com/user-attachments/assets/c5c1c631-4655-47c9-a129-5f48e13dc43e" />
