### PR TITLE
Additional graph config

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -374,6 +374,10 @@ components:
         name:
           type: string
           example: default
+        labels:
+          type: object
+          additionalProperties:
+            type: string
       required:
         - domain
         - type

--- a/cmd/cupdate/main.go
+++ b/cmd/cupdate/main.go
@@ -348,6 +348,7 @@ func main() {
 							Domain: "kubernetes",
 							Type:   string(n.Kind()),
 							Name:   n.Name(),
+							Labels: n.Labels().RemoveUnsupported(),
 						}
 						if node.Type() == "kubernetes/"+kubernetes.ResourceKindCoreV1Namespace {
 							namespaceNode = &node
@@ -357,6 +358,7 @@ func main() {
 							Domain: "docker",
 							Type:   string(n.Kind()),
 							Name:   n.Name(),
+							Labels: n.Labels().RemoveUnsupported(),
 						}
 						if node.Type() == "docker/"+docker.ResourceKindSwarmNamespace || node.Type() == "docker/"+docker.ResourceKindComposeProject {
 							namespaceNode = &node

--- a/docs/config.md
+++ b/docs/config.md
@@ -36,13 +36,70 @@ done using environment variables.
 Cupdate can take additional resource-specific configuration via the use of
 labels. For Docker, this means annotating the container image or the container /
 service itself. In Kubernetes, any resource in the image's tree can be annotated
-to configure Cupdate. See below for examples.
+to configure Cupdate.
 
 Each label has two aliases to follow both the Docker and Kubernetes conventions.
 
-| Label                                              | Description                                                          | Default |
-| -------------------------------------------------- | -------------------------------------------------------------------- | ------- |
-| `config.cupdate/ignore` or `cupdate.config.ignore` | Set to `true` to ignore the resource subtree (e.g. container / pod). | `false` |
+The web UI can be used to see what labels are used for a given image on the
+image's page, in the graph view. Nodes that have labels configured will have an
+icon / tooltip indicating that the behavior might differ from the defaults. The
+exact labels used can be seen by clicking on a node, which shows a dialog.
+
+#### `ignore`
+
+- Kubernetes: `config.cupdate/ignore`
+- Docker: `cupdate.config.ignore`
+
+Set to `true` to ignore the resource subtree (e.g. deployment, pod, or container
+). Defaults to `false`.
+
+#### `stay-on-current-major`
+
+- Kubernetes: `config.cupdate/stay-on-current-major`
+- Docker: `cupdate.config.stay-on-current-major`
+
+Set to `true` to stay on the current major track specified by images' semantic
+tags.
+
+Examples of updates made by Cupdate by default:
+
+- `alpine:3.21.2` -> `alpine:3.21.3` (patch on current major track)
+- `node:22.14.0` -> `node:23.8.0` (end of current major track, new major available)
+
+With `stay-on-current-major` set to `true`, Cupdate wouldn't recommend node to
+be updated as the newer version is no longer on the same major.
+
+This is useful for databases where updating to a newer major version can take a
+lot of time and require changes to applications.
+
+#### `pin`
+
+- Kubernetes: `config.cupdate/pin`
+- Docker: `cupdate.config.pin`
+
+Set to `true` to pin images' tags, meaning Cupdate will only recommend updates
+to the underlying manifest identified by the tag, as opposed to semantic
+updates.
+
+Examples of updates made by Cupdate by default:
+
+- `alpine:3.21.2` -> `alpine:3.21.3` (patch on current major track)
+- `node:22.14.0` -> `node:23.8.0` (end of current major track, new major available)
+
+With `pin` set to `true`, neither update would be recommended. However, Cupdate
+would still recommend updates like the following, if their tags have been
+overwritten, pointing to a newer manifest.
+
+- `latest` -> `latest`
+- `alpine:3` -> `alpine:3`
+
+This is useful for databases where updating to a newer version can take a lot of
+time and require changes to applications. It is recommended to only use `pin` if
+necessary, preferring the use of `stay-on-current-major` alongside a tag that
+specifies an as granular version as possible (i.e. `alpine:3.21.2` as opposed to
+`alpine:3`). But in cases where the tag is not necessarily semantic, such as
+where `12.0.0` -> `12.1.0` would mean a major change, `pin` can be used to force
+the tag to not change.
 
 #### Examples
 

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -125,9 +125,10 @@ type Graph struct {
 }
 
 type GraphNode struct {
-	Domain string `json:"domain"`
-	Type   string `json:"type"`
-	Name   string `json:"name"`
+	Domain string            `json:"domain"`
+	Type   string            `json:"type"`
+	Name   string            `json:"name"`
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 type ImageEvent struct {

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -54,6 +54,22 @@ func (l Labels) Pin() bool {
 	return false
 }
 
+func (l Labels) StayOnCurrentMajor() bool {
+	if l == nil {
+		return false
+	}
+
+	if v, ok := l["config.cupdate/stay-on-current-major"]; ok {
+		return v == "true"
+	}
+
+	if v, ok := l["cupdate.config.stay-on-current-major"]; ok {
+		return v == "true"
+	}
+
+	return false
+}
+
 // RemoveUnsupported removes unsupported labels.
 func (l Labels) RemoveUnsupported() Labels {
 	clone := maps.Clone(l)

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -38,6 +38,22 @@ func (l Labels) Ignore() bool {
 	return false
 }
 
+func (l Labels) Pin() bool {
+	if l == nil {
+		return false
+	}
+
+	if v, ok := l["config.cupdate/pin"]; ok {
+		return v == "true"
+	}
+
+	if v, ok := l["cupdate.config.pin"]; ok {
+		return v == "true"
+	}
+
+	return false
+}
+
 // RemoveUnsupported removes unsupported labels.
 func (l Labels) RemoveUnsupported() Labels {
 	clone := maps.Clone(l)

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
+	"strings"
 	"sync"
 	"time"
 
@@ -34,6 +36,17 @@ func (l Labels) Ignore() bool {
 	}
 
 	return false
+}
+
+// RemoveUnsupported removes unsupported labels.
+func (l Labels) RemoveUnsupported() Labels {
+	clone := maps.Clone(l)
+	for k := range l {
+		if !strings.HasPrefix(k, "config.cupdate/") && !strings.HasPrefix(k, "cupdate.config.") {
+			delete(clone, k)
+		}
+	}
+	return clone
 }
 
 type Graph = *graph.Graph[Node]

--- a/internal/semver/utils.go
+++ b/internal/semver/utils.go
@@ -14,7 +14,7 @@ func CompareVersions(a *Version, b *Version) int {
 // If the current version is the newest version of the major, the latest version
 // is returned. This allows more graceful handling of version tracks for things
 // like databases where multiple majors are supported concurrently.
-func LatestOpinionatedVersionString(current string, versions []string) (string, bool) {
+func LatestOpinionatedVersionString(current string, versions []string, stayOnCurrentMajor bool) (string, bool) {
 	if current == "latest" {
 		return current, true
 	}
@@ -66,8 +66,9 @@ func LatestOpinionatedVersionString(current string, versions []string) (string, 
 		}
 	}
 
-	// End of major track, return the latest version
-	if latestVersionOfSameMajor.Equals(currentVersion) {
+	// End of major track, return the latest version unless we want to stay on the
+	// current major
+	if latestVersionOfSameMajor.Equals(currentVersion) && !stayOnCurrentMajor {
 		return latestVersion.raw, compatibleFound
 	}
 

--- a/internal/semver/utils_test.go
+++ b/internal/semver/utils_test.go
@@ -141,15 +141,23 @@ func TestLatestVersionOnSameTrack(t *testing.T) {
 	}
 
 	testCases := []struct {
-		Version  string
-		Expected string
-		OK       bool
+		Version            string
+		StayOnCurrentMajor bool
+		Expected           string
+		OK                 bool
 	}{
 		{
 			// End of major, expected latest major
 			Version:  "5",
 			Expected: "7",
 			OK:       true,
+		},
+		{
+			// End of major, expected same major
+			Version:            "5",
+			StayOnCurrentMajor: true,
+			Expected:           "5",
+			OK:                 true,
 		},
 		{
 			// Patch on same major track
@@ -202,6 +210,13 @@ func TestLatestVersionOnSameTrack(t *testing.T) {
 			OK:       true,
 		},
 		{
+			// Apparent end of same major track - recommend newest
+			Version:            "6.0.19",
+			StayOnCurrentMajor: true,
+			Expected:           "6.0.19",
+			OK:                 true,
+		},
+		{
 			// Latest available
 			Version:  "8.0.4",
 			Expected: "8.0.4",
@@ -230,7 +245,7 @@ func TestLatestVersionOnSameTrack(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Version, func(t *testing.T) {
-			actual, ok := LatestOpinionatedVersionString(testCase.Version, versions)
+			actual, ok := LatestOpinionatedVersionString(testCase.Version, versions, testCase.StayOnCurrentMajor)
 			assert.Equal(t, testCase.Expected, actual)
 			assert.Equal(t, testCase.OK, ok)
 		})

--- a/internal/workflow/imageworkflow/getlatestversion.go
+++ b/internal/workflow/imageworkflow/getlatestversion.go
@@ -52,7 +52,7 @@ func GetLatestReference() workflow.Step {
 
 				// We only want to specify a latest reference when we're certain of it,
 				// for example, when it has been seen in the list of tags
-				latest, ok := semver.LatestOpinionatedVersionString(reference.Tag, tags)
+				latest, ok := semver.LatestOpinionatedVersionString(reference.Tag, tags, labels.StayOnCurrentMajor())
 				if ok {
 					l := reference
 

--- a/internal/workflow/imageworkflow/workflow.go
+++ b/internal/workflow/imageworkflow/workflow.go
@@ -39,7 +39,8 @@ func New(httpClient *httputil.Client, data *Data) workflow.Workflow {
 					GetLatestReference().
 						WithID("latest").
 						With("registryClient", workflow.Ref{Key: "step.registry.client"}).
-						With("reference", data.ImageReference),
+						With("reference", data.ImageReference).
+						With("graph", data.Graph),
 					GetManifest().
 						WithID("latest-manifest").
 						WithCondition(workflow.ValueExists("step.latest.reference")).

--- a/web/api.ts
+++ b/web/api.ts
@@ -70,6 +70,7 @@ export interface GraphNode {
   domain: string
   type: string
   name: string
+  labels?: Record<string, string>
 }
 
 export interface WorkflowRun {

--- a/web/components/DependencyGraphNode.tsx
+++ b/web/components/DependencyGraphNode.tsx
@@ -1,6 +1,8 @@
 import type { JSX, ReactNode } from 'react'
 import type { GraphNode } from '../api'
 import type { NodeProps } from './GraphRenderer'
+import { InfoTooltip } from './InfoTooltip'
+import { FluentTag16Regular } from './icons/fluent-tag-16-regular'
 import { SimpleIconsDocker } from './icons/simple-icons-docker'
 import { SimpleIconsKubernetes } from './icons/simple-icons-kubernetes'
 import { SimpleIconsOci } from './icons/simple-icons-oci'
@@ -47,14 +49,22 @@ export function DependencyGraphNode({
   }
 
   return (
-    <div className="px-4 py-2 shadow-md rounded-md bg-white dark:bg-[#262626] border-2 border-[#ebebeb] dark:border-[#333333]">
+    <div className="px-4 py-2 cursor-pointer shadow-md rounded-md bg-white dark:bg-[#262626] border-2 border-[#ebebeb] dark:border-[#333333]">
       <div className="flex">
         <div className="rounded-full w-12 h-12 flex justify-center items-center bg-gray-100 dark:bg-[#363a3a] shrink-0">
           {label}
         </div>
         <div className="ml-2 grow min-w-0">
-          <div className="text-lg font-bold truncate">
-            {titles[data.domain]?.[data.type] || data.type}
+          <div className="flex items-center">
+            <div className="text-lg font-bold truncate flex-grow">
+              {titles[data.domain]?.[data.type] || data.type}
+            </div>
+            {data.labels && Object.keys(data.labels).length > 0 && (
+              <InfoTooltip icon={<FluentTag16Regular />}>
+                This node has labels that might affect how the image is
+                processed.
+              </InfoTooltip>
+            )}
           </div>
           <div className="text-gray-500 truncate">{data.name}</div>
         </div>

--- a/web/components/icons/fluent-tag-16-regular.tsx
+++ b/web/components/icons/fluent-tag-16-regular.tsx
@@ -1,0 +1,20 @@
+import type { SVGProps } from 'react'
+
+export function FluentTag16Regular(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      role="img"
+      aria-label="icon"
+      xmlns="http://www.w3.org/2000/svg"
+      width="16px"
+      height="16px"
+      viewBox="0 0 16 16"
+      {...props}
+    >
+      <path
+        fill="currentColor"
+        d="M11 6a1 1 0 1 0 0-2a1 1 0 0 0 0 2m-8.413 4.136a1.99 1.99 0 0 1 0-2.822l4.74-4.716a2 2 0 0 1 1.41-.584L11.986 2A2 2 0 0 1 14 4.01l-.024 3.363a2 2 0 0 1-.588 1.396l-4.67 4.647a2.01 2.01 0 0 1-2.835 0zm.709-2.116a.994.994 0 0 0 0 1.41l3.296 3.28c.392.39 1.026.39 1.418 0l4.67-4.647a1 1 0 0 0 .293-.698l.024-3.363a1 1 0 0 0-1.006-1.004l-3.25.013a1 1 0 0 0-.705.292z"
+      />
+    </svg>
+  )
+}

--- a/web/pages/image-page/GraphCard.tsx
+++ b/web/pages/image-page/GraphCard.tsx
@@ -1,8 +1,99 @@
-import { type JSX, useMemo } from 'react'
+import {
+  type JSX,
+  type ReactNode,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import type { Graph, GraphNode } from '../../api'
 import { DependencyGraphNode } from '../../components/DependencyGraphNode'
 import { GraphRenderer } from '../../components/GraphRenderer'
+import { SimpleIconsDocker } from '../../components/icons/simple-icons-docker'
+import { SimpleIconsKubernetes } from '../../components/icons/simple-icons-kubernetes'
+import { SimpleIconsOci } from '../../components/icons/simple-icons-oci'
 import { useGraphLayout } from '../../graph'
+
+const titles: Record<string, Record<string, string | undefined> | undefined> = {
+  oci: {
+    image: 'Image',
+  },
+  kubernetes: {
+    'core/v1/pod': 'Pod',
+    'core/v1/namespace': 'Namespace',
+    'core/v1/container': 'Container',
+    'apps/v1/deployment': 'Deployment',
+    'apps/v1/daemonset': 'Daemon set',
+    'apps/v1/replicaset': 'Replica set',
+    'batch/v1/job': 'Job',
+    'batch/v1/cronjob': 'Cron job',
+    'apps/v1/statefulset': 'Stateful set',
+    unknown: '<unknown resource>',
+  },
+  docker: {
+    container: 'Container',
+    'swarm/task': 'Task',
+    'swarm/service': 'Service',
+    'swarm/namespace': 'Namespace',
+    'compose/service': 'Service',
+    'compose/project': 'Project',
+  },
+}
+
+type GraphNodeProps = {
+  ref: React.RefObject<HTMLDialogElement | null>
+  graphNode: GraphNode | undefined
+}
+
+function GraphNodeDialog({ ref, graphNode }: GraphNodeProps): JSX.Element {
+  let label: ReactNode
+  switch (graphNode?.domain) {
+    case 'oci':
+      label = <SimpleIconsOci className="text-blue-400" />
+      break
+    case 'kubernetes':
+      label = <SimpleIconsKubernetes className="text-blue-400" />
+      break
+    case 'docker':
+      label = <SimpleIconsDocker className="text-blue-500" />
+  }
+
+  return (
+    // biome-ignore lint/a11y/useKeyWithClickEvents: The dialog element already handles ESC
+    <dialog
+      ref={ref}
+      className="backdrop:bg-black/20 backdrop:backdrop-blur-sm bg-transparent m-auto"
+      onClick={(e) => e.target === ref.current && ref.current.close()}
+    >
+      <div className="rounded-lg bg-white dark:bg-[#1e1e1e] px-4 py-6 shadow w-[90vw] max-w-[800px] max-h-[80vh] overflow-y-scroll">
+        <p className="font-bold">
+          {graphNode
+            ? titles[graphNode.domain]?.[graphNode.type] || graphNode.type
+            : ''}
+        </p>
+        <p className="text-sm opacity-60">{graphNode?.name}</p>
+        {graphNode?.labels && (
+          <>
+            <p className="mt-2">Labels</p>
+            <dl className="grid grid-cols-2">
+              {graphNode?.labels &&
+                Object.entries(graphNode.labels).map(([k, v]) => (
+                  <>
+                    <dt key={`${k}-dt`} className="text-sm">
+                      <code>{k}</code>
+                    </dt>
+                    <dd key={`${k}-dd`} className="text-sm">
+                      <code>{v}</code>
+                    </dd>
+                  </>
+                ))}
+            </dl>
+          </>
+        )}
+      </div>
+    </dialog>
+  )
+}
 
 type GraphCardProps = {
   graph: Graph
@@ -43,12 +134,22 @@ export function GraphCard({ graph }: GraphCardProps): JSX.Element {
     options
   )
 
+  const [graphNode, setGraphNode] = useState<GraphNode>()
+  const dialogRef = useRef<HTMLDialogElement>(null)
+
+  const showGraphNode = useCallback((graphNode: GraphNode) => {
+    setGraphNode(graphNode)
+    dialogRef.current?.showModal()
+  }, [])
+
   return (
     <div className="rounded-lg bg-white dark:bg-[#1e1e1e] px-4 py-2 shadow-sm h-[480px]">
+      <GraphNodeDialog ref={dialogRef} graphNode={graphNode} />
       <GraphRenderer
         edges={edges}
         nodes={nodes}
         bounds={bounds}
+        onNodeClick={(node) => showGraphNode(node.data)}
         NodeElement={DependencyGraphNode}
       />
     </div>


### PR DESCRIPTION
Store Cupdate labels set on graph nodes to the database.

Add two labels to control version selection:

- "pin" will pin the exact tag set, only updating underlying manifests
- "stay on current major" will recommend new semantic versions, for as long as they don't leave the current major track

For improved understanding of the config, make it possible to see the labels in the image graph.

<img width="211" alt="image" src="https://github.com/user-attachments/assets/0f759091-ba64-4181-9bff-b189f33d4106" />


<img width="831" alt="image" src="https://github.com/user-attachments/assets/e132e432-e852-4c54-9b0b-4af5b3553801" />

<img width="499" alt="image" src="https://github.com/user-attachments/assets/53fe3461-b226-4440-ad3c-bd61855b86c2" />

<img width="889" alt="image" src="https://github.com/user-attachments/assets/d4f29bbe-d249-47cf-8c49-fe53f89169ac" />

<img width="861" alt="image" src="https://github.com/user-attachments/assets/8339e207-3ca4-4c2a-8bda-6254d013dd00" />

<img width="892" alt="image" src="https://github.com/user-attachments/assets/6aa22a58-1309-49dc-b1bc-a6d6a69023cf" />
