### PR TITLE
Refactor docker client, support http, https, mTLS

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -5,31 +5,32 @@
 Cupdate requires zero configuration, but is very configurable. Configuration is
 done using environment variables.
 
-| Environment variable                    | Description                                                                                                           | Default                         |
-| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| `CUPDATE_LOG_LEVEL`                     | `debug`, `info`, `warn`, `error`                                                                                      | `info`                          |
-| `CUPDATE_API_ADDRESS`                   | The address to expose the API on.                                                                                     | `0.0.0.0`                       |
-| `CUPDATE_API_PORT`                      | The port to expose the API on.                                                                                        | `8080`                          |
-| `CUPDATE_WEB_DISABLED`                  | Whether or not to disable the web UI.                                                                                 | `false`                         |
-| `CUPDATE_WEB_ADDRESS`                   | The URL at which the UI is available (such as `https://example.com`). Used for RSS feeds, should generally not be set | Automatically resolved          |
-| `CUPDATE_HTTP_USER_AGENT`               | The User Agent string to use for HTTP requests.                                                                       | `Cupdate/1.0`                   |
-| `CUPDATE_CACHE_PATH`                    | A path to the boltdb file in which to store cache.                                                                    | `cachev1.boltdb`                |
-| `CUPDATE_CACHE_MAX_AGE`                 | The maximum age of cache entries.                                                                                     | `24h`                           |
-| `CUPDATE_DB_PATH`                       | A path to the sqlite file in which to store data.                                                                     | `dbv1.sqlite`                   |
-| `CUPDATE_PROCESSING_INTERVAL`           | The interval between worker runs.                                                                                     | `1h`                            |
-| `CUPDATE_PROCESSING_ITEMS`              | The number of items (images) to process each worker run.                                                              | `10`                            |
-| `CUPDATE_PROCESSING_MIN_AGE`            | The minimum age of an item (image) before being processed.                                                            | `72h`                           |
-| `CUPDATE_PROCESSING_TIMEOUT`            | The maximum time one image may take to process before being terminated.                                               | `2m`                            |
-| `CUPDATE_PROCESSING_QUEUE_BURST`        | Number of items that can be processed in a short burst.                                                               | `10`                            |
-| `CUPDATE_PROCESSING_QUEUE_RATE`         | The desired processing rate under normal circumstances.                                                               | `1m`                            |
-| `CUPDATE_WORKFLOW_CLEANUP_MAX_AGE`      | The maximum age of a workflow run before it's removed.                                                                | `48h`                           |
-| `CUPDATE_WORKFLOW_CLEANUP_INTERVAL`     | The time between workflow run cleanup iterations.                                                                     | `1h`                            |
-| `CUPDATE_KUBERNETES_HOST`               | The host of the Kubernetes API. For use with proxying.                                                                | Required to use Kubernetes.     |
-| `CUPDATE_DOCKER_HOST`                   | One or more comma-separated Docker host URIs. Supports unix://path, tcp://host:port, http:// and https:// URIs.       | Required to use Docker.         |
-| `CUPDATE_DOCKER_INCLUDE_ALL_CONTAINERS` | Whether or not to include containers in any state, not just running containers.                                       | `false`                         |
-| `CUPDATE_OTEL_TARGET`                   | Target URL to an Open Telemetry GRPC ingest endpoint.                                                                 | Required to use Open Telemetry. |
-| `CUPDATE_OTEL_INSECURE`                 | Disable client transport security for the Open Telemetry GRPC connection.                                             | `false`                         |
-| `CUPDATE_REGISTRY_SECRETS`              | Path to a JSON file containing registry secrets. See Docker's config.json and Kubernetes' `imagePullSecrets`.         | None                            |
+| Environment variable                    | Description                                                                                                           | Default                                               |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `CUPDATE_LOG_LEVEL`                     | `debug`, `info`, `warn`, `error`                                                                                      | `info`                                                |
+| `CUPDATE_API_ADDRESS`                   | The address to expose the API on.                                                                                     | `0.0.0.0`                                             |
+| `CUPDATE_API_PORT`                      | The port to expose the API on.                                                                                        | `8080`                                                |
+| `CUPDATE_WEB_DISABLED`                  | Whether or not to disable the web UI.                                                                                 | `false`                                               |
+| `CUPDATE_WEB_ADDRESS`                   | The URL at which the UI is available (such as `https://example.com`). Used for RSS feeds, should generally not be set | Automatically resolved.                               |
+| `CUPDATE_HTTP_USER_AGENT`               | The User Agent string to use for HTTP requests.                                                                       | `Cupdate/1.0`                                         |
+| `CUPDATE_CACHE_PATH`                    | A path to the boltdb file in which to store cache.                                                                    | `cachev1.boltdb`                                      |
+| `CUPDATE_CACHE_MAX_AGE`                 | The maximum age of cache entries.                                                                                     | `24h`                                                 |
+| `CUPDATE_DB_PATH`                       | A path to the sqlite file in which to store data.                                                                     | `dbv1.sqlite`                                         |
+| `CUPDATE_PROCESSING_INTERVAL`           | The interval between worker runs.                                                                                     | `1h`                                                  |
+| `CUPDATE_PROCESSING_ITEMS`              | The number of items (images) to process each worker run.                                                              | `10`                                                  |
+| `CUPDATE_PROCESSING_MIN_AGE`            | The minimum age of an item (image) before being processed.                                                            | `72h`                                                 |
+| `CUPDATE_PROCESSING_TIMEOUT`            | The maximum time one image may take to process before being terminated.                                               | `2m`                                                  |
+| `CUPDATE_PROCESSING_QUEUE_BURST`        | Number of items that can be processed in a short burst.                                                               | `10`                                                  |
+| `CUPDATE_PROCESSING_QUEUE_RATE`         | The desired processing rate under normal circumstances.                                                               | `1m`                                                  |
+| `CUPDATE_WORKFLOW_CLEANUP_MAX_AGE`      | The maximum age of a workflow run before it's removed.                                                                | `48h`                                                 |
+| `CUPDATE_WORKFLOW_CLEANUP_INTERVAL`     | The time between workflow run cleanup iterations.                                                                     | `1h`                                                  |
+| `CUPDATE_KUBERNETES_HOST`               | The host of the Kubernetes API. For use with proxying.                                                                | Required to use Kubernetes.                           |
+| `CUPDATE_DOCKER_HOST`                   | One or more comma-separated Docker host URIs. Supports unix://path, tcp://host:port, http:// and https:// URIs.       | Required to use Docker.                               |
+| `CUPDATE_DOCKER_TLS_PATH`               | Path to a directory containing certificates and keys for Docker. See Docker-specific docs for details.                | Required to use Docker with mTLS or a self-signed CA. |
+| `CUPDATE_DOCKER_INCLUDE_ALL_CONTAINERS` | Whether or not to include containers in any state, not just running containers.                                       | `false`                                               |
+| `CUPDATE_OTEL_TARGET`                   | Target URL to an Open Telemetry GRPC ingest endpoint.                                                                 | Required to use Open Telemetry.                       |
+| `CUPDATE_OTEL_INSECURE`                 | Disable client transport security for the Open Telemetry GRPC connection.                                             | `false`                                               |
+| `CUPDATE_REGISTRY_SECRETS`              | Path to a JSON file containing registry secrets. See Docker's config.json and Kubernetes' `imagePullSecrets`.         | None.                                                 |
 
 ### Labels
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -25,7 +25,7 @@ done using environment variables.
 | `CUPDATE_WORKFLOW_CLEANUP_MAX_AGE`      | The maximum age of a workflow run before it's removed.                                                                | `48h`                           |
 | `CUPDATE_WORKFLOW_CLEANUP_INTERVAL`     | The time between workflow run cleanup iterations.                                                                     | `1h`                            |
 | `CUPDATE_KUBERNETES_HOST`               | The host of the Kubernetes API. For use with proxying.                                                                | Required to use Kubernetes.     |
-| `CUPDATE_DOCKER_HOST`                   | One or more comma-separated Docker host URIs. Supports unix://path and tcp://host:port URIs.                          | Required to use Docker.         |
+| `CUPDATE_DOCKER_HOST`                   | One or more comma-separated Docker host URIs. Supports unix://path, tcp://host:port, http:// and https:// URIs.       | Required to use Docker.         |
 | `CUPDATE_DOCKER_INCLUDE_ALL_CONTAINERS` | Whether or not to include containers in any state, not just running containers.                                       | `false`                         |
 | `CUPDATE_OTEL_TARGET`                   | Target URL to an Open Telemetry GRPC ingest endpoint.                                                                 | Required to use Open Telemetry. |
 | `CUPDATE_OTEL_INSECURE`                 | Disable client transport security for the Open Telemetry GRPC connection.                                             | `false`                         |

--- a/docs/docker/README.md
+++ b/docs/docker/README.md
@@ -51,6 +51,56 @@ Whilst the commands above are enough to get you started with Cupdate, you might
 want to change some configuration to better suite your needs. Please see the
 additional documentation in [../config.md](../config.md).
 
+### TLS
+
+By specifying a Docker host such as `https://docker.internal`, Cupdate will
+automatically use TLS. However, many setups configure Docker using a self-signed
+certificate chain. In such setups, Cupdate needs to know what certificates to
+use. This is done by specifying the `CUPDATE_DOCKER_TLS_PATH` environment
+variable to point to a directory containing the config.
+
+Cupdate will look for the following files:
+
+- `ca.pem` - If found, will control the trusted root CAs. May contain multiple
+  certificates.
+- `cert.pem` + `key.pem` - If found, will enable mTLS.
+
+That is - if you don't want authentication, but still want TLS, it's enough to
+have a `ca.pem`. Likewise, if you want mTLS but have configured trust in the
+chain elsewhere, you can specify only `cert.pem` and `key.pem`.
+
+In simple cases, like when you only have a single host, you can put the files
+immediately in the specified directory.
+
+```shell
+${CUPDATE_DOCKER_TLS_PATH}
+├── ca.pem
+├── cert.pem
+└── key.pem
+```
+
+If you want to specify certificates for each host, create a subdirectory for the
+host's hostname (e.g. `docker.internal` or `192.168.0.116`) and put your files
+there.
+
+```shell
+${CUPDATE_DOCKER_TLS_PATH}
+├── ca.pem
+├── cert.pem
+├── key.pem
+└── docker.internal # Overrides for the host docker.internal
+    ├── ca.pem
+    ├── cert.pem
+    └── key.pem
+```
+
+If **no** applicable files are found in the subdirectory, the defaults, if any,
+will be used.
+
+The directory structure borrows from
+[Uptime Kuma](https://github.com/louislam/uptime-kuma/wiki/How-to-Monitor-Docker-Containers)
+to have a somewhat standard layout.
+
 ## Updating Cupdate
 
 > [!NOTE]

--- a/internal/configutils/mtls.go
+++ b/internal/configutils/mtls.go
@@ -1,0 +1,74 @@
+package configutils
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// LoadTLSConfig reads a TLS config from the first directory containing one or
+// both of the following files:
+//
+//   - ca.pem
+//   - cert.pem + key.pem
+//
+// If none are found, a nil config is returned.
+func LoadTLSConfig(basePath ...string) (*tls.Config, error) {
+	if len(basePath) == 0 {
+		return nil, nil
+	}
+
+	if len(basePath) > 1 {
+		for _, basePath := range basePath {
+			tlsConfig, err := LoadTLSConfig(basePath)
+			if err != nil {
+				return nil, err
+			}
+
+			if tlsConfig != nil {
+				return tlsConfig, nil
+			}
+		}
+	}
+
+	b := basePath[0]
+
+	config := &tls.Config{}
+
+	// Load the client certificate and key (if any)
+	{
+		certificate, err := tls.LoadX509KeyPair(filepath.Join(b, "cert.pem"), filepath.Join(b, "key.pem"))
+		if errors.Is(err, os.ErrNotExist) {
+			// Do nothing
+		} else if err != nil {
+			return nil, err
+		} else {
+			config.Certificates = []tls.Certificate{certificate}
+		}
+	}
+
+	// Load the certificate authority (if any)
+	{
+		caFile, err := os.ReadFile(filepath.Join(b, "ca.pem"))
+		if errors.Is(err, os.ErrNotExist) {
+			// Do nothing
+		} else if err != nil {
+			return nil, err
+		} else {
+			rootCAs := x509.NewCertPool()
+			if ok := rootCAs.AppendCertsFromPEM(caFile); !ok {
+				return nil, fmt.Errorf("invalid CA PEM file")
+			}
+			config.RootCAs = rootCAs
+		}
+	}
+
+	if config.Certificates == nil && config.RootCAs == nil {
+		return nil, nil
+	}
+
+	return config, nil
+}

--- a/internal/configutils/mtls_test.go
+++ b/internal/configutils/mtls_test.go
@@ -1,0 +1,170 @@
+package configutils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// CA:
+// openssl ecparam -out cakey.pem -name secp256r1 -genkey
+// openssl req -new -x509 -days 3650 -key cakey.pem -sha256 -out ca.pem
+// Client:
+// openssl ecparam -out key.pem -name secp256r1 -genkey
+// openssl req -new -key key.pem -out csr.pem
+// openssl x509 -req -days 3650 -sha256 -in csr.pem -CA ca.pem -CAkey cakey.pem -out cert.pem
+// Cleanup:
+// rm cakey.pem csr.pem
+const ca string = `-----BEGIN CERTIFICATE-----
+MIIB1jCCAX2gAwIBAgIUHeqn9ag/smJys2AMJyDVQAobXw0wCgYIKoZIzj0EAwIw
+QTELMAkGA1UEBhMCU0UxEzARBgNVBAgMClNvbWUtU3RhdGUxEDAOBgNVBAoMB0N1
+cGRhdGUxCzAJBgNVBAMMAkNBMB4XDTI1MDMxOTE3MTQzNVoXDTM1MDMxNzE3MTQz
+NVowQTELMAkGA1UEBhMCU0UxEzARBgNVBAgMClNvbWUtU3RhdGUxEDAOBgNVBAoM
+B0N1cGRhdGUxCzAJBgNVBAMMAkNBMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE
+oCVYVx5I/+sOz8se2ZcGZ07CsRwsY9kb8TsS4xM2Z6AQrTvcsZVh28CcL8I2xJNV
+dkj2GK8XQkps7GEyv8v7baNTMFEwHQYDVR0OBBYEFMs72Xafqu6EFpRTBT3EmuRa
+vppeMB8GA1UdIwQYMBaAFMs72Xafqu6EFpRTBT3EmuRavppeMA8GA1UdEwEB/wQF
+MAMBAf8wCgYIKoZIzj0EAwIDRwAwRAIgVtGsCJzcVupejmAx9hi6h7ZKAPZC4Fb5
+5etd1q85owwCIDdIR5u7xqdva0ilBjcQmnsHi2LC7iDYZ9Rr4ZEK6Fcz
+-----END CERTIFICATE-----`
+
+const cert string = `-----BEGIN CERTIFICATE-----
+MIIByTCCAXCgAwIBAgIUeGl/z36HycMF8sgA7jZOsR4WHcAwCgYIKoZIzj0EAwIw
+QTELMAkGA1UEBhMCU0UxEzARBgNVBAgMClNvbWUtU3RhdGUxEDAOBgNVBAoMB0N1
+cGRhdGUxCzAJBgNVBAMMAkNBMB4XDTI1MDMxOTE3MTcxNloXDTM1MDMxNzE3MTcx
+NlowRTELMAkGA1UEBhMCU0UxEzARBgNVBAgMClNvbWUtU3RhdGUxEDAOBgNVBAoM
+B0N1cGRhdGUxDzANBgNVBAMMBkNsaWVudDBZMBMGByqGSM49AgEGCCqGSM49AwEH
+A0IABIF5YkSZ5/yKH3sKgRhfrl5eEaltih3KPgfmcMuGpTznEeB/SRgiVftWBM6A
+5JLobTQ1Svcg3KsWpkULs+ak51GjQjBAMB0GA1UdDgQWBBSEKbBSTW8Htp1u4wPn
+7E9ofkksnTAfBgNVHSMEGDAWgBTLO9l2n6ruhBaUUwU9xJrkWr6aXjAKBggqhkjO
+PQQDAgNHADBEAiBKfWgK6/LVa+gtnDsykjwxzip0VWgZFmwlrUv2wBe7aQIgcatE
+7rEEMp4YbA99DFsvRXerg97oj2DClYdhyluH2n0=
+-----END CERTIFICATE-----`
+
+const key string = `-----BEGIN EC PARAMETERS-----
+BggqhkjOPQMBBw==
+-----END EC PARAMETERS-----
+-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIOnlh+ikteP7wkYOVBlx/86WAv5K7QpgFbVyQiR96eX1oAoGCCqGSM49
+AwEHoUQDQgAEgXliRJnn/IofewqBGF+uXl4RqW2KHco+B+Zwy4alPOcR4H9JGCJV
++1YEzoDkkuhtNDVK9yDcqxamRQuz5qTnUQ==
+-----END EC PRIVATE KEY-----`
+
+func TestLoadTLSConfig(t *testing.T) {
+	testCases := []struct {
+		Name         string
+		BasePath     []string
+		FS           fstest.MapFS
+		ExpectCA     bool
+		ExpectClient bool
+	}{
+		{
+			Name:     "Full config from host",
+			BasePath: []string{"192.168.0.116"},
+			FS: fstest.MapFS{
+				"192.168.0.116/ca.pem":   &fstest.MapFile{Data: []byte(ca)},
+				"192.168.0.116/cert.pem": &fstest.MapFile{Data: []byte(cert)},
+				"192.168.0.116/key.pem":  &fstest.MapFile{Data: []byte(key)},
+			},
+			ExpectCA:     true,
+			ExpectClient: true,
+		},
+		{
+			Name:     "Only mTLS from host",
+			BasePath: []string{"192.168.0.116"},
+			FS: fstest.MapFS{
+				"192.168.0.116/cert.pem": &fstest.MapFile{Data: []byte(cert)},
+				"192.168.0.116/key.pem":  &fstest.MapFile{Data: []byte(key)},
+			},
+			ExpectCA:     false,
+			ExpectClient: true,
+		},
+		{
+			Name:     "Only CA from host",
+			BasePath: []string{"192.168.0.116"},
+			FS: fstest.MapFS{
+				"192.168.0.116/ca.pem": &fstest.MapFile{Data: []byte(ca)},
+			},
+			ExpectCA:     true,
+			ExpectClient: false,
+		},
+		{
+			Name:         "Empty from host",
+			BasePath:     []string{"192.168.0.116"},
+			FS:           fstest.MapFS{},
+			ExpectCA:     false,
+			ExpectClient: false,
+		},
+		{
+			Name:     "Full config from fallback",
+			BasePath: []string{"192.168.0.116", ""},
+			FS: fstest.MapFS{
+				"ca.pem":   &fstest.MapFile{Data: []byte(ca)},
+				"cert.pem": &fstest.MapFile{Data: []byte(cert)},
+				"key.pem":  &fstest.MapFile{Data: []byte(key)},
+			},
+			ExpectCA:     true,
+			ExpectClient: true,
+		},
+		{
+			Name:     "Only mTLS from fallback",
+			BasePath: []string{"192.168.0.116", ""},
+			FS: fstest.MapFS{
+				"cert.pem": &fstest.MapFile{Data: []byte(cert)},
+				"key.pem":  &fstest.MapFile{Data: []byte(key)},
+			},
+			ExpectCA:     false,
+			ExpectClient: true,
+		},
+		{
+			Name:     "Only CA from fallback",
+			BasePath: []string{"192.168.0.116", ""},
+			FS: fstest.MapFS{
+				"ca.pem": &fstest.MapFile{Data: []byte(ca)},
+			},
+			ExpectCA:     true,
+			ExpectClient: false,
+		},
+		{
+			Name:         "Empty from fallback",
+			BasePath:     []string{"192.168.0.116"},
+			FS:           fstest.MapFS{},
+			ExpectCA:     false,
+			ExpectClient: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			root := t.TempDir()
+			err := os.CopyFS(root, testCase.FS)
+			require.NoError(t, err)
+
+			basePath := make([]string, len(testCase.BasePath))
+			for i, b := range testCase.BasePath {
+				basePath[i] = filepath.Join(root, b)
+			}
+
+			config, err := LoadTLSConfig(basePath...)
+			require.NoError(t, err)
+
+			if testCase.ExpectCA {
+				require.NotNil(t, config)
+				assert.NotNil(t, config.RootCAs)
+			}
+
+			if testCase.ExpectClient {
+				require.NotNil(t, config)
+				assert.NotNil(t, config.Certificates)
+			}
+
+			if !testCase.ExpectCA && !testCase.ExpectClient {
+				assert.Nil(t, config)
+			}
+		})
+	}
+}

--- a/internal/httputil/client.go
+++ b/internal/httputil/client.go
@@ -30,6 +30,16 @@ type Requester interface {
 
 var _ prometheus.Collector = (*Client)(nil)
 
+// NewTransport returns a [*http.Transport] with sane defaults.
+func NewTransport() *http.Transport {
+	return &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout: 5 * time.Second,
+		}).DialContext,
+		TLSHandshakeTimeout: 5 * time.Second,
+	}
+}
+
 type Client struct {
 	http.Client
 
@@ -46,13 +56,8 @@ type Client struct {
 func NewClient(cache cache.Cache, maxAge time.Duration) *Client {
 	return &Client{
 		Client: http.Client{
-			Transport: &http.Transport{
-				DialContext: (&net.Dialer{
-					Timeout: 5 * time.Second,
-				}).DialContext,
-				TLSHandshakeTimeout: 5 * time.Second,
-			},
-			Timeout: 10 * time.Second,
+			Transport: NewTransport(),
+			Timeout:   10 * time.Second,
 		},
 
 		cache:       cache,

--- a/internal/platform/docker/platform_test.go
+++ b/internal/platform/docker/platform_test.go
@@ -1,0 +1,137 @@
+package docker
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPlatform(t *testing.T) {
+	testCases := []struct {
+		// URI is the URI to the docker API.
+		//
+		// To handle dynamic ports, the following strings are replaced:
+		//
+		//   - <http host> -> server http host:port
+		//   - <https host> -> server https host:port
+		//   - <socket path> -> UNIX domain socket path
+		URI         string
+		UseTLS      bool
+		ExpectedErr bool
+	}{
+		{
+			URI: "http://<http host>",
+		},
+		{
+			URI:    "https://<https host>",
+			UseTLS: true,
+		},
+		{
+			URI: "https://<http host>",
+			// HTTPS on HTTP port
+			ExpectedErr: true,
+		},
+		{
+			URI: "tcp://<http host>",
+		},
+		{
+			URI:    "tcp://<https host>",
+			UseTLS: true,
+		},
+		{
+			URI: "tcp://<http host>",
+			// TLS on TCP port
+			UseTLS:      true,
+			ExpectedErr: true,
+		},
+		{
+			URI: "unix://<socket path>",
+		},
+		{
+			URI: "unix:///tmp/enoent",
+			// Supported scheme, socket not found
+			ExpectedErr: true,
+		},
+		{
+			URI: "ftp://<http host>",
+			// Unsupported scheme
+			ExpectedErr: true,
+		},
+		{
+			URI: "",
+			// Missing URI
+			ExpectedErr: true,
+		},
+		{
+			URI: "http://<http host>!<-+",
+			// Supported scheme, invalid URL
+			ExpectedErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.URI, func(t *testing.T) {
+			// NOTE: The path becomes quite long when using t.TempDir(), which
+			// includes the test case's name. If it becomes too long, at least on
+			// macOS, the binding of the socket will fail. Keep the test names short
+			socketPath := filepath.Join(t.TempDir(), "socket")
+			listener, err := net.Listen("unix", socketPath)
+			// NOTE: Debugging weird errors here, such as binding failed? Look at the
+			// above note
+			require.NoError(t, err)
+
+			mux := http.NewServeMux()
+			mux.HandleFunc("GET /version", func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(`{"ApiVersion":"1.0","MinAPIVersion":"1.0"}`))
+			})
+
+			server := &http.Server{
+				Handler: mux,
+			}
+			go func() {
+				err := server.Serve(listener)
+				require.ErrorIs(t, err, http.ErrServerClosed)
+			}()
+			defer server.Close()
+
+			httpProxyServer := httptest.NewServer(server.Handler)
+			defer httpProxyServer.Close()
+
+			httpProxyURL, err := url.Parse(httpProxyServer.URL)
+			require.NoError(t, err)
+
+			httpsProxyServer := httptest.NewTLSServer(server.Handler)
+			defer httpsProxyServer.Close()
+
+			httpsProxyURL, err := url.Parse(httpsProxyServer.URL)
+			require.NoError(t, err)
+
+			uri := testCase.URI
+			uri = strings.ReplaceAll(uri, "<http host>", httpProxyURL.Host)
+			uri = strings.ReplaceAll(uri, "<https host>", httpsProxyURL.Host)
+			uri = strings.ReplaceAll(uri, "<socket path>", socketPath)
+
+			options := &Options{}
+			if testCase.UseTLS {
+				options.TLSClientConfig = httpsProxyServer.TLS.Clone()
+				options.TLSClientConfig.InsecureSkipVerify = true
+			}
+
+			_, err = NewPlatform(context.TODO(), uri, options)
+			if testCase.ExpectedErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/tools/sockproxy/main.go
+++ b/tools/sockproxy/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"maps"
 	"net"
 	"net/http"
 	"os"
@@ -45,9 +46,7 @@ func main() {
 		defer res.Body.Close()
 
 		header := w.Header()
-		for k, v := range res.Header {
-			header[k] = v
-		}
+		maps.Copy(header, res.Header)
 
 		w.WriteHeader(res.StatusCode)
 		if _, err := io.Copy(w, res.Body); err != nil {


### PR DESCRIPTION
- Refactor the docker platform client.
- Add support for HTTP and HTTPs
- Add unit tests for the initialization and usage of the transport
- Add support for mTLS

Solves: #178
