### PR TITLE
Add hosts / nodes to the dependency graph

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -421,6 +421,10 @@ components:
           type: object
           additionalProperties:
             type: string
+        internalLabels:
+          type: object
+          additionalProperties:
+            type: string
       required:
         - domain
         - type

--- a/cmd/cupdate/main.go
+++ b/cmd/cupdate/main.go
@@ -373,20 +373,22 @@ func main() {
 					switch n := node.(type) {
 					case kubernetes.Resource:
 						mappedNodes[node.ID()] = models.GraphNode{
-							Domain: "kubernetes",
-							Type:   string(n.Kind()),
-							Name:   n.Name(),
-							Labels: n.Labels().RemoveUnsupported(),
+							Domain:         "kubernetes",
+							Type:           string(n.Kind()),
+							Name:           n.Name(),
+							Labels:         n.Labels().RemoveUnsupported(),
+							InternalLabels: n.InternalLabels(),
 						}
 						if node.Type() == "kubernetes/"+kubernetes.ResourceKindCoreV1Namespace {
 							namespaceNode = &node
 						}
 					case docker.Resource:
 						mappedNodes[node.ID()] = models.GraphNode{
-							Domain: "docker",
-							Type:   string(n.Kind()),
-							Name:   n.Name(),
-							Labels: n.Labels().RemoveUnsupported(),
+							Domain:         "docker",
+							Type:           string(n.Kind()),
+							Name:           n.Name(),
+							Labels:         n.Labels().RemoveUnsupported(),
+							InternalLabels: n.InternalLabels(),
 						}
 						if node.Type() == "docker/"+docker.ResourceKindSwarmNamespace || node.Type() == "docker/"+docker.ResourceKindComposeProject {
 							namespaceNode = &node
@@ -399,16 +401,16 @@ func main() {
 				}
 
 				// Resolve labels for the image node. The nearest label takes precedence
-				resolvedImageLabels := make(map[string]string)
+				resolvedLabels := make(map[string]string)
 				queue := []string{root.ID()}
 				for len(queue) > 0 {
 					id := queue[0]
 					queue = queue[1:]
 
 					for k, v := range mappedNodes[id].Labels {
-						_, ok := resolvedImageLabels[k]
+						_, ok := resolvedLabels[k]
 						if !ok {
-							resolvedImageLabels[k] = v
+							resolvedLabels[k] = v
 						}
 					}
 
@@ -419,10 +421,11 @@ func main() {
 					}
 				}
 				mappedNodes[root.ID()] = models.GraphNode{
-					Domain: "oci",
-					Type:   "image",
-					Name:   imageNode.Reference.String(),
-					Labels: resolvedImageLabels,
+					Domain:         "oci",
+					Type:           "image",
+					Name:           imageNode.Reference.String(),
+					Labels:         resolvedLabels,
+					InternalLabels: nil,
 				}
 
 				tags := []string{}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -142,10 +142,11 @@ type Graph struct {
 }
 
 type GraphNode struct {
-	Domain string            `json:"domain"`
-	Type   string            `json:"type"`
-	Name   string            `json:"name"`
-	Labels map[string]string `json:"labels,omitempty"`
+	Domain         string            `json:"domain"`
+	Type           string            `json:"type"`
+	Name           string            `json:"name"`
+	Labels         map[string]string `json:"labels,omitempty"`
+	InternalLabels map[string]string `json:"internalLabels,omitempty"`
 }
 
 type ImageEvent struct {

--- a/internal/platform/docker/models.go
+++ b/internal/platform/docker/models.go
@@ -1,0 +1,12 @@
+package docker
+
+type Version struct {
+	// Version is the version of Docker.
+	Version      string `json:"Version"`
+	OS           string `json:"Os"`
+	Architecture string `json:"Arch"`
+	// MinimumAPIVersion is the minimum support API version.
+	MinimumAPIVersion string `json:"MinAPIVersion"`
+	// APIVersion is the current API version.
+	APIVersion string `json:"ApiVersion"`
+}

--- a/internal/platform/docker/resources.go
+++ b/internal/platform/docker/resources.go
@@ -10,6 +10,7 @@ import (
 type ResourceKind string
 
 const (
+	ResourceKindHost           = "host"
 	ResourceKindContainer      = "container"
 	ResourceKindSwarmTask      = "swarm/task"
 	ResourceKindSwarmService   = "swarm/service"
@@ -21,7 +22,7 @@ const (
 // IsSupported returns whether or not the resource is supported.
 func (r ResourceKind) IsSupported() bool {
 	switch r {
-	case ResourceKindContainer, ResourceKindSwarmTask,
+	case ResourceKindHost, ResourceKindContainer, ResourceKindSwarmTask,
 		ResourceKindSwarmService, ResourceKindSwarmNamespace,
 		ResourceKindComposeProject, ResourceKindComposeService:
 		return true
@@ -44,10 +45,11 @@ type Resource interface {
 var _ Resource = (*resource)(nil)
 
 type resource struct {
-	id     string
-	kind   ResourceKind
-	name   string
-	labels platform.Labels
+	id             string
+	kind           ResourceKind
+	name           string
+	labels         platform.Labels
+	internalLabels platform.InternalLabels
 }
 
 // ID implements platform.Node.
@@ -75,6 +77,11 @@ func (r resource) Labels() platform.Labels {
 	return r.labels
 }
 
+// InternalLabels implements platform.Node.
+func (r resource) InternalLabels() platform.InternalLabels {
+	return r.internalLabels
+}
+
 // String implements Resource.
 func (r resource) String() string {
 	return fmt.Sprintf("%s<%s>", r.kind, r.name)
@@ -84,6 +91,8 @@ func (r resource) String() string {
 // Panics if [ResourceKind.IsSupported] returns false.
 func TagName(kind ResourceKind) string {
 	switch kind {
+	case ResourceKindHost:
+		return "host"
 	case ResourceKindContainer:
 		return "container"
 	case ResourceKindSwarmTask:

--- a/internal/platform/kubernetes/resources.go
+++ b/internal/platform/kubernetes/resources.go
@@ -16,6 +16,7 @@ const (
 	ResourceKindAppsV1StatefulSet = "apps/v1/statefulset"
 	ResourceKindBatchV1CronJob    = "batch/v1/cronjob"
 	ResourceKindBatchV1Job        = "batch/v1/job"
+	ResourceKindCoreV1Node        = "core/v1/node"
 	ResourceKindCoreV1Namespace   = "core/v1/namespace"
 	ResourceKindCoreV1Pod         = "core/v1/pod"
 	ResourceKindCoreV1Container   = "core/v1/container"
@@ -29,8 +30,8 @@ func (r ResourceKind) IsSupported() bool {
 	case ResourceKindAppsV1Deployment, ResourceKindAppsV1DaemonSet,
 		ResourceKindAppsV1ReplicaSet, ResourceKindAppsV1StatefulSet,
 		ResourceKindBatchV1CronJob, ResourceKindBatchV1Job,
-		ResourceKindCoreV1Namespace, ResourceKindCoreV1Pod,
-		ResourceKindCoreV1Container:
+		ResourceKindCoreV1Node, ResourceKindCoreV1Namespace,
+		ResourceKindCoreV1Pod, ResourceKindCoreV1Container:
 		return true
 	default:
 		return false
@@ -51,10 +52,11 @@ type Resource interface {
 var _ Resource = (*resource)(nil)
 
 type resource struct {
-	id     string
-	kind   ResourceKind
-	name   string
-	labels platform.Labels
+	id             string
+	kind           ResourceKind
+	name           string
+	labels         platform.Labels
+	internalLabels platform.InternalLabels
 }
 
 // ID implements platform.Node.
@@ -82,6 +84,11 @@ func (r resource) Labels() platform.Labels {
 	return r.labels
 }
 
+// InternalLabels implements platform.Node.
+func (r resource) InternalLabels() platform.InternalLabels {
+	return r.internalLabels
+}
+
 // String implements Resource.
 func (r resource) String() string {
 	return fmt.Sprintf("%s<%s>", r.kind, r.name)
@@ -103,6 +110,8 @@ func TagName(kind ResourceKind) string {
 		return "cron job"
 	case ResourceKindBatchV1Job:
 		return "job"
+	case ResourceKindCoreV1Node:
+		return "node"
 	case ResourceKindCoreV1Namespace:
 		return "namespace"
 	case ResourceKindCoreV1Pod:

--- a/internal/platform/kubernetes/utils.go
+++ b/internal/platform/kubernetes/utils.go
@@ -59,7 +59,7 @@ func getImageReference(specImage string, statusImage string, statusImageID strin
 	return specRef, nil
 }
 
-func addObjectToGraph(graph platform.Graph, resources map[types.UID]v1.Object, object v1.Object) {
+func addObjectToGraph(graph platform.Graph, nodeResource resource, resources map[types.UID]v1.Object, object v1.Object) {
 	objectResource := mapObjectToResource(object)
 
 	ownerReferences := object.GetOwnerReferences()
@@ -70,7 +70,7 @@ func addObjectToGraph(graph platform.Graph, resources map[types.UID]v1.Object, o
 
 		// The resource has no owning entity, just add the resource to the graph
 		if namespace == "" {
-			graph.InsertTree(objectResource)
+			graph.InsertTree(objectResource, nodeResource)
 			return
 		}
 
@@ -82,7 +82,9 @@ func addObjectToGraph(graph platform.Graph, resources map[types.UID]v1.Object, o
 				id:   fmt.Sprintf("kubernetes/%s", namespace),
 				name: namespace,
 			},
+			nodeResource,
 		)
+
 		return
 	}
 
@@ -110,8 +112,8 @@ func addObjectToGraph(graph platform.Graph, resources map[types.UID]v1.Object, o
 			ownerResource,
 		)
 
-		// Assuming there are no cycles,continue to traverse the hierarchy
-		addObjectToGraph(graph, resources, ownerObject)
+		// Assuming there are no cycles, continue to traverse the hierarchy
+		addObjectToGraph(graph, nodeResource, resources, ownerObject)
 	}
 }
 

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -22,6 +22,8 @@ type Node interface {
 	Type() string
 	// Labels returns labels set on the resource represented by the node.
 	Labels() Labels
+	// InternalLabels returns labels set by Cupdate.
+	InternalLabels() InternalLabels
 }
 
 // Labels holds labels / annotations found by platform implementations, which
@@ -91,12 +93,36 @@ func (l Labels) RemoveUnsupported() Labels {
 	return clone
 }
 
+const (
+	InternalLabelHostArchitecture string = "host-architecture"
+	InternalLabelOperatingSystem  string = "host-operating-system"
+)
+
+// InternalLabels holds labels maintained by Cupdate for use by Cupdate.
+type InternalLabels map[string]string
+
+func (l InternalLabels) InternalCupdateArchitecture() string {
+	if l == nil {
+		return ""
+	}
+
+	return l[InternalLabelHostArchitecture]
+}
+
+func (l InternalLabels) InternalCupdateOperatingSystem() string {
+	if l == nil {
+		return ""
+	}
+
+	return l[InternalLabelOperatingSystem]
+}
+
 // Graph is a graph implementation holding [Nodes].
 type Graph = *graph.Graph[Node]
 
 var _ Node = (*ImageNode)(nil)
 
-// ImageNode represents resource common to all platforms - the OCI image.
+// ImageNode represents a resource common to all platforms - the OCI image.
 type ImageNode struct {
 	Reference oci.Reference
 }
@@ -113,6 +139,11 @@ func (n ImageNode) Type() string {
 
 // Labels implements Node.
 func (n ImageNode) Labels() Labels {
+	return nil
+}
+
+// InternalLabels implements Node.
+func (n ImageNode) InternalLabels() InternalLabels {
 	return nil
 }
 

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -45,6 +45,11 @@ func (m *TestNode) Labels() Labels {
 	return nil
 }
 
+// InternalLabels implements Node.
+func (m *TestNode) InternalLabels() InternalLabels {
+	return nil
+}
+
 func TestCompoundGrapherHappyPath(t *testing.T) {
 	graph1 := NewGraph()
 	graph1.InsertTree(

--- a/web/api.ts
+++ b/web/api.ts
@@ -71,6 +71,7 @@ export interface GraphNode {
   type: string
   name: string
   labels?: Record<string, string>
+  internalLabels?: Record<string, string>
 }
 
 export interface ImageScorecard {

--- a/web/components/DependencyGraphNode.tsx
+++ b/web/components/DependencyGraphNode.tsx
@@ -12,6 +12,7 @@ const titles: Record<string, Record<string, string | undefined> | undefined> = {
     image: 'Image',
   },
   kubernetes: {
+    'core/v1/node': 'Node',
     'core/v1/pod': 'Pod',
     'core/v1/namespace': 'Namespace',
     'core/v1/container': 'Container',

--- a/web/pages/image-page/GraphCard.tsx
+++ b/web/pages/image-page/GraphCard.tsx
@@ -20,6 +20,7 @@ const titles: Record<string, Record<string, string | undefined> | undefined> = {
     image: 'Image',
   },
   kubernetes: {
+    'core/v1/node': 'Node',
     'core/v1/pod': 'Pod',
     'core/v1/namespace': 'Namespace',
     'core/v1/container': 'Container',
@@ -38,7 +39,13 @@ const titles: Record<string, Record<string, string | undefined> | undefined> = {
     'swarm/namespace': 'Namespace',
     'compose/service': 'Service',
     'compose/project': 'Project',
+    host: 'Host',
   },
+}
+
+const internalLabels: Record<string, string> = {
+  'host-architecture': 'Architecture',
+  'host-operating-system': 'Operating system',
 }
 
 type GraphNodeProps = {
@@ -104,6 +111,21 @@ function GraphNodeDialog({ ref, graphNode }: GraphNodeProps): JSX.Element {
               <li>
                 <code className="break-all">Digest: {oci.digest}</code>
               </li>
+            </ul>
+          </>
+        )}
+        {graphNode?.internalLabels && (
+          <>
+            <p className="mt-2">Details</p>
+            <ul className="text-sm">
+              {graphNode?.internalLabels &&
+                Object.entries(graphNode.internalLabels).map(([k, v]) => (
+                  <li key={`${k}`}>
+                    <code>
+                      {internalLabels[k] || k}: {v}
+                    </code>
+                  </li>
+                ))}
             </ul>
           </>
         )}


### PR DESCRIPTION
Start tracking Docker hosts / Kubernetes nodes in the dependency graph,
alongside information about their architecture and operating system.

This should provide us with information useful for identifying possible
architectures used by images, letting us filter and identify platform-
dependent information.

![image](https://github.com/user-attachments/assets/f739e356-37a7-4fc5-8e23-005de6526081)

