### PR TITLE
Split failed status tag to failed and incomplete

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1411,7 +1411,7 @@ func (s *Store) Summary(ctx context.Context) (*models.ImagePageSummary, error) {
 	res.Close()
 
 	// Total raw images
-	res, err = s.db.QueryContext(ctx, `SELECT COUNT(1) FROM images_tags WHERE tag='failed';`)
+	res, err = s.db.QueryContext(ctx, `SELECT COUNT(1) FROM images_tags WHERE tag='status:failed';`)
 	if err != nil {
 		return nil, err
 	}

--- a/web/pages/Dashboard.tsx
+++ b/web/pages/Dashboard.tsx
@@ -161,7 +161,7 @@ export function Dashboard(): JSX.Element {
             </div>
           </Link>
           <Link
-            to="/?tag=failed"
+            to="/?tag=status:failed"
             className="rounded-lg focus:bg-white hover:bg-white dark:focus:bg-[#1e1e1e] dark:hover:bg-[#1e1e1e] transition-colors"
             tabIndex={0}
           >

--- a/web/tags.ts
+++ b/web/tags.ts
@@ -158,9 +158,20 @@ export const Tags: Tag[] = [
     color: palette.negative,
   },
   {
+    // TODO: Remove in v1. Replaced with prefixed version
     name: 'failed',
     description: 'Failed images',
     color: palette.negative,
+  },
+  {
+    name: 'status:failed',
+    description: 'Failed images',
+    color: palette.negative,
+  },
+  {
+    name: 'status:incomplete',
+    description: 'Incomplete information',
+    color: palette.warning,
   },
 
   // Security warnings


### PR DESCRIPTION
Add two new tags to replace the failed tag: status:failed and
status:incomplete. The workflow is considered failed if the OCI job was
unsuccessful. All other failures will cause the workflow to be marked as
being incomplete.

Solves: #211
