### PR TITLE
Fix regression where image tags were not removed

### DIFF
--- a/internal/store/init.go
+++ b/internal/store/init.go
@@ -13,7 +13,7 @@ import (
 	_ "embed" // Embed SQL files
 )
 
-const Revision = 5
+const Revision = 6
 
 //go:embed migrations
 var migrations embed.FS

--- a/internal/store/migrations/5.sql
+++ b/internal/store/migrations/5.sql
@@ -1,0 +1,22 @@
+-- Source revision: 5
+-- Target revision: 6
+-- Summary: Cascade delete tags (#143)
+
+-- TODO: Remove in v1
+
+-- Clean up
+DELETE FROM images_tags WHERE reference NOT IN (SELECT reference FROM images);
+
+-- Cascade can't be added in ALTER in sqlite
+ALTER TABLE images_tags RENAME TO images_tags_old;
+
+CREATE TABLE images_tags (
+  reference TEXT NOT NULL,
+  tag TEXT NOT NULL,
+  PRIMARY KEY (reference, tag),
+  FOREIGN KEY(reference) REFERENCES images(reference) ON DELETE CASCADE
+);
+
+INSERT INTO images_tags SELECT * FROM images_tags_old;
+
+INSERT INTO revision (id, revision) VALUES (0, 6) ON CONFLICT DO UPDATE SET revision=excluded.revision;

--- a/internal/store/schemas/00_init.sql
+++ b/internal/store/schemas/00_init.sql
@@ -3,7 +3,7 @@ CREATE TABLE revision (
   id INTEGER PRIMARY KEY CHECK (id = 0),
   revision INT NOT NULL
 );
-INSERT INTO revision (id, revision) VALUES (0, 5);
+INSERT INTO revision (id, revision) VALUES (0, 6);
 
 CREATE TABLE raw_images (
   reference TEXT PRIMARY KEY NOT NULL,


### PR DESCRIPTION
Fix regression of #143 where image tags were not removed  after the SQL
migration framework was added.

Adds a migration to alter the images_tags table to properly cascade
delete removed images.
