### PR TITLE
Fix GitHub releases not showing

### DIFF
--- a/internal/workflow/imageworkflow/workflow.go
+++ b/internal/workflow/imageworkflow/workflow.go
@@ -458,11 +458,9 @@ func New(httpClient httputil.Requester, data *Data) workflow.Workflow {
 				},
 			},
 			{
-				ID:   "github",
-				Name: "Get GitHub information",
-				// Depend on whatever provides us with the latest image version
-				// Implicitly depends on OCI
-				DependsOn: []string{"docker", "ghcr", "gitlab"},
+				ID:        "github",
+				Name:      "Get GitHub information",
+				DependsOn: []string{"oci"},
 				// Only run for images with a reference to GitHub
 				If: func(ctx workflow.Context) (bool, error) {
 					if data.ImageReference.Domain == "ghcr.io" {


### PR DESCRIPTION
For Docker Hub images that have been connected to a GitHub repository,
we can identify releases, but due depending on the ghcr job, which can
be skipped, the job was not always run.

Solve this by not depending on any job but the OCI one, which is the one
actually in use these days.
