### PR TITLE
Fix z-index of toast vs card header

### DIFF
--- a/web/App.tsx
+++ b/web/App.tsx
@@ -18,7 +18,7 @@ export function App(): JSX.Element {
 
   return (
     <>
-      <div className="fixed top-0 left-0 h-[64px] w-full grid grid-cols-3 items-center shadow-sm bg-white/90 dark:bg-[#1e1e1e]/70 z-100 backdrop-blur-md">
+      <div className="fixed top-0 left-0 h-[64px] w-full grid grid-cols-3 items-center shadow-sm bg-white/90 dark:bg-[#1e1e1e]/70 z-250 backdrop-blur-md">
         <div className="justify-self-start ml-5">
           {location.pathname !== '/' && (
             <Link

--- a/web/components/InfoTooltip.tsx
+++ b/web/components/InfoTooltip.tsx
@@ -11,7 +11,7 @@ export function InfoTooltip({
       {icon || <FluentInfo16Regular />}
       <span
         role="tooltip"
-        className="starting:opacity-0 transition-opacity absolute hidden group-hover/tooltip:block bottom-full p-2 left-2/4 -translate-x-2/4 z-50 text-black dark:text-[#dddddd]"
+        className="starting:opacity-0 transition-opacity absolute hidden group-hover/tooltip:block bottom-full p-2 left-2/4 -translate-x-2/4 z-200 text-black dark:text-[#dddddd]"
       >
         <div className="p-2 bg-white dark:bg-[#292929] border-solid border-[1px] border-[#d9d9d9] dark:border-[#454545] rounded-sm w-60 text-xs text-left font-normal shadow-around">
           {children}

--- a/web/components/TagSelect.tsx
+++ b/web/components/TagSelect.tsx
@@ -153,7 +153,7 @@ export function TagSelect({
       {isOpen && (
         <div
           ref={menuRef}
-          className="absolute -top-4 -left-4 p-2 z-50 text-black dark:text-[#dddddd]"
+          className="absolute -top-4 -left-4 p-2 z-150 text-black dark:text-[#dddddd]"
         >
           <div className="flex max-h-64 overflow-y-auto flex-col gap-y-2 py-2 px-3 pr-6 bg-white dark:bg-[#292929] border-solid border-[1px] border-[#d0d0d0]/95 dark:border-[#505050] rounded-lg w-max shadow">
             {tags

--- a/web/pages/Dashboard.tsx
+++ b/web/pages/Dashboard.tsx
@@ -119,7 +119,7 @@ export function Dashboard(): JSX.Element {
 
   return (
     <>
-      <div className="fixed bottom-0 right-0 p-4 z-50">
+      <div className="fixed bottom-0 right-0 p-4 z-100">
         {isUpdateAvailable && (
           <Toast
             title="New data available"

--- a/web/pages/ImagePage.tsx
+++ b/web/pages/ImagePage.tsx
@@ -98,7 +98,7 @@ export function ImagePage(): JSX.Element {
 
   return (
     <>
-      <div className="fixed bottom-0 right-0 p-4 z-50">
+      <div className="fixed bottom-0 right-0 p-4 z-100">
         {isUpdateAvailable && (
           <Toast
             title="New data available"


### PR DESCRIPTION
Revisit the z-index for applicable elements. Fixes an issue where the
update toast was shown below a card's header in the image page.
