### PR TITLE
Fix OpenSSF scorecard not being collected

### DIFF
--- a/internal/workflow/job.go
+++ b/internal/workflow/job.go
@@ -25,7 +25,7 @@ type Job struct {
 	Steps []Step
 	// DependsOn optionally holds the ids of jobs that must complete for this job
 	// to run.
-	// Jobs will only run if its dependencies all succeeded.
+	// Jobs will not run if one of its dependencies fail.
 	DependsOn []string
 	// If holds a [Condition] that must pass for this job to run.
 	If Condition

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -112,7 +112,7 @@ func (w Workflow) Run(ctx context.Context) (models.WorkflowRun, error) {
 							errs[i] = ctx.Err()
 							return
 						case <-done[index]:
-							if errs[index] != nil {
+							if errs[index] != nil && errs[index] != ErrSkipped {
 								log.WarnContext(ctx, "Skipping job as dependent job failed", slog.String("dependency", dependency))
 								// Propagate error so that jobs fail if a dependency's
 								// dependency fails.

--- a/internal/workflow/workflow_test.go
+++ b/internal/workflow/workflow_test.go
@@ -123,13 +123,61 @@ func TestWorkflowRun(t *testing.T) {
 					},
 					{
 						JobID:  "job4",
-						Result: models.JobRunResultSkipped,
+						Result: models.JobRunResultSucceeded,
 						Steps: []models.StepRun{
 							{
 								Result: models.StepRunResultSkipped,
 							},
 						},
 						DependsOn: []string{"job3"},
+					},
+				},
+			},
+		},
+		{
+			// Some jobs can have multiple dependencies, some of which are optional
+			Name: "Continues if dependency is skipped",
+			Workflow: Workflow{
+				Jobs: []Job{
+					{
+						ID: "job1",
+						If: ConditionFunc(func(ctx Context) (bool, error) {
+							return false, nil
+						}),
+						Steps: []Step{},
+					},
+					{
+						ID:        "job2",
+						DependsOn: []string{"job1"},
+						Steps: []Step{
+							{
+								ID: "step1",
+								Main: func(ctx Context) (Command, error) {
+									return nil, nil
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectedRun: models.WorkflowRun{
+				Result: models.WorkflowRunResultSucceeded,
+				Jobs: []models.JobRun{
+					{
+						JobID:     "job1",
+						Result:    models.JobRunResultSkipped,
+						Steps:     []models.StepRun{},
+						DependsOn: []string{},
+					},
+					{
+						JobID:  "job2",
+						Result: models.JobRunResultSucceeded,
+						Steps: []models.StepRun{
+							{
+								Result: models.StepRunResultSucceeded,
+							},
+						},
+						DependsOn: []string{"job1"},
 					},
 				},
 			},


### PR DESCRIPTION
Ensure that job dependencies are optional to allow the jobs to handle
missing values themselves. This solves an issue where the OpenSSF
scorecard was not identified as the job was dependent on two mutually
exclusive jobs, one of which was always skipped.
