### PR TITLE
Debounce Kubernetes events

### DIFF
--- a/cmd/cupdate/config.go
+++ b/cmd/cupdate/config.go
@@ -60,8 +60,9 @@ type Config struct {
 	} `envPrefix:"WORKFLOW_"`
 
 	Kubernetes struct {
-		Host                  string `env:"HOST"`
-		IncludeOldReplicaSets bool   `env:"INCLUDE_OLD_REPLICAS"`
+		Host                  string        `env:"HOST"`
+		IncludeOldReplicaSets bool          `env:"INCLUDE_OLD_REPLICAS"`
+		DebounceInterval      time.Duration `env:"DEBOUNCE_INTERVAL" envDefault:"1m"`
 	} `envPrefix:"KUBERNETES_"`
 
 	Docker struct {

--- a/cmd/cupdate/main.go
+++ b/cmd/cupdate/main.go
@@ -87,7 +87,11 @@ func main() {
 			os.Exit(1)
 		}
 
-		targetPlatform, err = kubernetes.NewPlatform(kubernetesConfig, &kubernetes.Options{IncludeOldReplicaSets: config.Kubernetes.IncludeOldReplicaSets})
+		options := &kubernetes.Options{
+			IncludeOldReplicaSets: config.Kubernetes.IncludeOldReplicaSets,
+			DebounceInterval:      config.Kubernetes.DebounceInterval,
+		}
+		targetPlatform, err = kubernetes.NewPlatform(kubernetesConfig, options)
 		if err != nil {
 			slog.ErrorContext(ctx, "Failed to create kubernetes source", slog.Any("error", err))
 			os.Exit(1)

--- a/docs/config.md
+++ b/docs/config.md
@@ -25,6 +25,7 @@ done using environment variables.
 | `CUPDATE_WORKFLOW_CLEANUP_MAX_AGE`      | The maximum age of a workflow run before it's removed.                                                                | `48h`                                                 |
 | `CUPDATE_WORKFLOW_CLEANUP_INTERVAL`     | The time between workflow run cleanup iterations.                                                                     | `1h`                                                  |
 | `CUPDATE_KUBERNETES_HOST`               | The host of the Kubernetes API. For use with proxying.                                                                | Required to use Kubernetes.                           |
+| `CUPDATE_KUBERNETES_DEBOUNCE_INTERVAL`  | The minimum time between graphs.                                                                                      | `1m`                                                  |
 | `CUPDATE_DOCKER_HOST`                   | One or more comma-separated Docker host URIs. Supports unix://path, tcp://host:port, http:// and https:// URIs.       | Required to use Docker.                               |
 | `CUPDATE_DOCKER_TLS_PATH`               | Path to a directory containing certificates and keys for Docker. See Docker-specific docs for details.                | Required to use Docker with mTLS or a self-signed CA. |
 | `CUPDATE_DOCKER_INCLUDE_ALL_CONTAINERS` | Whether or not to include containers in any state, not just running containers.                                       | `false`                                               |

--- a/docs/kubernetes/README.md
+++ b/docs/kubernetes/README.md
@@ -50,6 +50,16 @@ By default, Cupdate will ignore old replica sets kept around by Kubernetes to
 enable rollback of services. To include them, set
 `CUPDATE_KUBERNETES_INCLUDE_OLD_REPLICAS` to `true`.
 
+Cupdate uses an event-driven architecture to keep its state up-to-date and
+properly reflecting Kubernetes. That means that when applicable resources are
+changed, Cupdate will produce an initial graph of relationships and images in
+use and make it available to the user. Though the processing is cheap and the
+events are debounced and API calls cached by default, it could result in
+additional API calls made to the Kubernetes APIs. These should cheap as well. If
+resources are frequently changed, (more than once every minute or so) you can
+control the delay by using the `CUPDATE_KUBERNETES_DEBOUNCE_INTERVAL`
+environment variable.
+
 Whilst the commands above are enough to get you started with Cupdate, you might
 want to change some configuration to better suite your needs. Please see the
 additional documentation in [../config.md](../config.md).

--- a/internal/platform/kubernetes/debounce.go
+++ b/internal/platform/kubernetes/debounce.go
@@ -1,0 +1,54 @@
+package kubernetes
+
+import (
+	"time"
+)
+
+// Debounce debounces messages sent to ch, returning at most one message per
+// interval. The latest message sent to ch during a debounced time window, if
+// any, will be sent the next window.
+func Debounce[T any](ch <-chan T, interval time.Duration) <-chan T {
+	out := make(chan T)
+
+	go func() {
+		defer close(out)
+
+		var debouncedValue *T
+		for {
+			// For each time window, either send the latest debounced value, or wait
+			// for one to be sent on ch
+			var value T
+			var ok bool
+			if debouncedValue == nil {
+				value, ok = <-ch
+			} else {
+				value = *debouncedValue
+				debouncedValue = nil
+				ok = true
+			}
+			if !ok {
+				return
+			}
+
+			out <- value
+
+			// During the debounced window, keep track of the latest value received
+			debounce := time.After(interval)
+		debounce:
+			for {
+				select {
+				case v, ok := <-ch:
+					if !ok {
+						return
+					}
+
+					debouncedValue = &v
+				case <-debounce:
+					break debounce
+				}
+			}
+		}
+	}()
+
+	return out
+}

--- a/internal/platform/kubernetes/debounce_test.go
+++ b/internal/platform/kubernetes/debounce_test.go
@@ -1,0 +1,33 @@
+package kubernetes
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDebounce(t *testing.T) {
+	incoming := make(chan time.Time)
+
+	outgoing := Debounce(incoming, 1*time.Second)
+
+	// The first message is passed immediately
+	in := time.Now()
+	incoming <- in
+	<-outgoing
+	assert.LessOrEqual(t, time.Since(in), 200*time.Millisecond)
+
+	// Messages sent during the debounce window are consumed without locking
+	incoming <- time.Now()
+	incoming <- time.Now()
+	incoming <- time.Now()
+	incoming <- time.Now()
+	incoming <- time.Now()
+
+	// The last message sent in a time window is passed in the next
+	in = time.Now()
+	incoming <- in
+	<-outgoing
+	assert.GreaterOrEqual(t, time.Since(in), 1*time.Second)
+}


### PR DESCRIPTION
In some Kubernetes environments, resources are changed very frequently
(as in multiple times every minute). This will cause Cupdate to create a
cheap initial graph of the environment. This can result in additional
API calls to the Kubernetes APIs. These are cached, but the traffic can
be unwanted.

To let users control the load, debounce the events by default and make
the debounce interval configurable.
