### PR TITLE
Update to go 1.25.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY web web
 ARG CUPDATE_VERSION="development build"
 RUN VITE_CUPDATE_VERSION="${CUPDATE_VERSION}" yarn build
 
-FROM --platform=${BUILDPLATFORM} golang:1.24.6@sha256:2c89c41fb9efc3807029b59af69645867cfe978d2b877d475be0d72f6c6ce6f6 AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.25.0@sha256:9e56f0d0f043a68bb8c47c819e47dc29f6e8f5129b8885bed9d43f058f7f3ed6 AS builder
 
 WORKDIR /src
 

--- a/cmd/cupdate/main.go
+++ b/cmd/cupdate/main.go
@@ -456,7 +456,7 @@ func main() {
 
 	httpServer := &http.Server{
 		Addr:    fmt.Sprintf("%s:%d", config.API.Address, config.API.Port),
-		Handler: mux,
+		Handler: http.NewCrossOriginProtection().Handler(mux),
 	}
 
 	wg.Go(func() error {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/AlexGustafsson/cupdate
 
-go 1.24.6
+go 1.25.0
 
 require (
 	github.com/caarlos0/env/v11 v11.3.1

--- a/internal/cache/disk.go
+++ b/internal/cache/disk.go
@@ -74,10 +74,7 @@ func NewDiskCache(path string) (*DiskCache, error) {
 		return nil, err
 	}
 
-	cache.wg.Add(1)
-	go func() {
-		defer cache.wg.Done()
-
+	cache.wg.Go(func() {
 		ticker := time.NewTicker(30 * time.Minute)
 		defer ticker.Stop()
 
@@ -99,7 +96,7 @@ func NewDiskCache(path string) (*DiskCache, error) {
 				return
 			}
 		}
-	}()
+	})
 
 	return cache, nil
 }

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -227,11 +227,9 @@ func (g *CompoundGrapher) Graph(ctx context.Context) (Graph, error) {
 	// issues
 	var wg sync.WaitGroup
 	for i, grapher := range g.Graphers {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			graphs[i], errs[i] = grapher.Graph(ctx)
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -88,9 +88,7 @@ func (w Workflow) Run(ctx context.Context) (models.WorkflowRun, error) {
 		job := w.Jobs[i]
 		log := log.With(slog.String("job", job.Name))
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			defer close(done[i])
 
 			if len(job.DependsOn) > 0 {
@@ -164,7 +162,7 @@ func (w Workflow) Run(ctx context.Context) (models.WorkflowRun, error) {
 				}
 			}
 			mutex.Unlock()
-		}()
+		})
 	}
 
 	wg.Wait()


### PR DESCRIPTION
- **Update to go v1.25.0**
- **Include otel source attributes in logs**
- **Use new WaitGroup.Go function**
- **Use new Cross-Site Request Forgery protection**
