### PR TITLE
Fix decoding of HTML character entities for GitHub

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -262,7 +262,7 @@ func parseAbout(r io.Reader) (string, error) {
 		return "", err
 	}
 
-	return strings.TrimSpace(buffer.String()), nil
+	return html.UnescapeString(strings.TrimSpace(buffer.String())), nil
 }
 
 func parseRelease(r io.Reader) (*Release, error) {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -37,7 +37,7 @@ func TestClientGetDescription(t *testing.T) {
 		Client: httputil.NewClient(cachetest.NewCache(t), 24*time.Hour),
 	}
 
-	release, err := c.GetDescription(context.TODO(), "renovatebot", "renovate")
+	release, err := c.GetDescription(context.TODO(), "jellyfin", "jellyfin")
 	require.NoError(t, err)
 
 	fmt.Printf("%+v\n", release)


### PR DESCRIPTION
Make sure to decode HTML character entities found in GitHub repository
descriptions.
