### PR TITLE
Fix zero-width space included when copying texts

### DIFF
--- a/web/components/ImageCard.tsx
+++ b/web/components/ImageCard.tsx
@@ -8,6 +8,7 @@ import { ImageLogo } from './ImageLogo'
 import { InfoTooltip } from './InfoTooltip'
 import { FluentShieldError16Filled } from './icons/fluent-shield-error-16-filled'
 import { FluentWarning16Filled } from './icons/fluent-warning-16-filled'
+import { WordBreak } from './WordBreak'
 
 export type ImageCardProps = {
   reference: string
@@ -52,7 +53,9 @@ export function ImageCard({
           <div
             className={`${compact ? 'flex flex-col-reverse' : 'flex items-center'}`}
           >
-            <p className="text-sm line-clamp-2 font-semibold">{name}</p>
+            <p className="text-sm line-clamp-2 font-semibold">
+              <WordBreak delimiter="/">{name}</WordBreak>
+            </p>
             {(tags.includes('vulnerability:critical') ||
               tags.includes('vulnerability:high')) && (
               <InfoTooltip

--- a/web/components/WordBreak.tsx
+++ b/web/components/WordBreak.tsx
@@ -1,0 +1,34 @@
+import type { JSX } from 'react'
+
+export type WordBreakProps = {
+  delimiter: string
+  children: string
+}
+
+/**
+ * WordBreak a text at a specific string / character.
+ * Useful to word break at specific delimiters like "/" where CSS options would
+ * otherwise cause breaking at unwanted characters.
+ */
+export function WordBreak({
+  children,
+  delimiter,
+}: WordBreakProps): JSX.Element {
+  const parts = children.split(delimiter)
+
+  return (
+    <>
+      {parts.map((part, i) => (
+        <>
+          {part}
+          {i < parts.length - 1 && (
+            <>
+              /
+              <wbr />
+            </>
+          )}
+        </>
+      ))}
+    </>
+  )
+}

--- a/web/pages/Dashboard.tsx
+++ b/web/pages/Dashboard.tsx
@@ -285,7 +285,7 @@ export function Dashboard(): JSX.Element {
               <ImageCard
                 className={`group/link-focus:shadow-md hover:shadow-md transition-shadow-sm cursor-pointer dark:transition-colors group-focus/link:bg-[#f5f5f5] dark:group-focus/link:bg-[#262626] dark:hover:bg-[#262626] ${layout === 'list' ? '' : 'h-[150px]'}`}
                 reference={x.reference}
-                name={name(x.reference).replaceAll('/', '/\u200b')}
+                name={name(x.reference)}
                 currentVersion={version(x.reference)}
                 fullCurrentVersion={fullVersion(x.reference)}
                 latestVersion={

--- a/web/pages/ImagePage.tsx
+++ b/web/pages/ImagePage.tsx
@@ -11,6 +11,7 @@ import { FluentChevronUp20Regular } from '../components/icons/fluent-chevron-up-
 import { FluentWarning16Filled } from '../components/icons/fluent-warning-16-filled'
 import { Markdown } from '../components/Markdown'
 import { Toast } from '../components/Toast'
+import { WordBreak } from '../components/WordBreak'
 import { type Event, useEvents } from '../EventProvider'
 import {
   useImage,
@@ -134,7 +135,7 @@ export function ImagePage(): JSX.Element {
         />
         {/* Image name */}
         <h1 className="text-2xl font-medium">
-          {name(image.value.reference).replaceAll('/', '/\u200b')}
+          <WordBreak delimiter="/">{name(image.value.reference)}</WordBreak>
         </h1>
         {/* Image version */}
         {/* Digests are formatted like <algo>:<digest>, such as sha256:<digest>. Show a maximum of 5 hex digits before truncating with ellipsis (hence 15ch) */}


### PR DESCRIPTION
In order to break long reference names at / on smaller screens to make
each part more easily readable, a zero-width space was previously added.

This had an undesired effect where the zero-width space was included
when copying the text.

Fix this issue by properly inserting a <wbr /> instead.
