### PR TITLE
Track annotations and expose them via the API

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -373,12 +373,20 @@ components:
           format: datetime
         description:
           type: string
+        annotations:
+          type: object
+          additionalProperties:
+            type: string
         lasestReference:
           type: string
           description: The latest available version on the same track
         latestCreated:
           type: string
           format: datetime
+        latestAnnotations:
+          type: object
+          additionalProperties:
+            type: string
         tags:
           type: array
           items:

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -4,6 +4,7 @@ package models
 import (
 	"time"
 
+	"github.com/AlexGustafsson/cupdate/internal/oci"
 	"github.com/AlexGustafsson/cupdate/internal/osv"
 )
 
@@ -31,17 +32,19 @@ type PaginationMetadata struct {
 }
 
 type Image struct {
-	Reference           string      `json:"reference"`
-	Created             *time.Time  `json:"created,omitempty"`
-	LatestReference     string      `json:"latestReference,omitempty"`
-	LatestCreated       *time.Time  `json:"latestCreated,omitempty"`
-	VersionDiffSortable uint64      `json:"-"`
-	Description         string      `json:"description,omitempty"`
-	Tags                []string    `json:"tags"`
-	Links               []ImageLink `json:"links"`
-	Vulnerabilities     int         `json:"vulnerabilities"`
-	LastModified        time.Time   `json:"lastModified"`
-	Image               string      `json:"image,omitempty"`
+	Reference           string          `json:"reference"`
+	Created             *time.Time      `json:"created,omitempty"`
+	Annotations         oci.Annotations `json:"annotations,omitempty"`
+	LatestReference     string          `json:"latestReference,omitempty"`
+	LatestCreated       *time.Time      `json:"latestCreated,omitempty"`
+	LatestAnnotations   oci.Annotations `json:"latestAnnotations,omitempty"`
+	VersionDiffSortable uint64          `json:"-"`
+	Description         string          `json:"description,omitempty"`
+	Tags                []string        `json:"tags"`
+	Links               []ImageLink     `json:"links"`
+	Vulnerabilities     int             `json:"vulnerabilities"`
+	LastModified        time.Time       `json:"lastModified"`
+	Image               string          `json:"image,omitempty"`
 }
 
 type RawImage struct {

--- a/internal/store/init.go
+++ b/internal/store/init.go
@@ -11,7 +11,7 @@ import (
 	_ "embed" // Embed SQL files
 )
 
-const Revision = 7
+const Revision = 8
 
 //go:embed migrations
 var migrations embed.FS

--- a/internal/store/migrations/7.sql
+++ b/internal/store/migrations/7.sql
@@ -1,0 +1,10 @@
+-- Source revision: 7
+-- Target revision: 8
+-- Summary: Track annotations
+
+-- TODO: Remove in v1
+
+ALTER TABLE images ADD annotations BLOB;
+ALTER TABLE images ADD latestAnnotations BLOB;
+
+INSERT INTO revision (id, revision) VALUES (0, 8) ON CONFLICT DO UPDATE SET revision=excluded.revision;

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/AlexGustafsson/cupdate/internal/models"
+	"github.com/AlexGustafsson/cupdate/internal/oci"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -52,10 +53,16 @@ func TestStoreInsertImage(t *testing.T) {
 	defer store.Close()
 
 	expected := &models.Image{
-		Reference:       "mongo:4",
+		Reference: "mongo:4",
+		Annotations: oci.Annotations{
+			"version": "4.0.0",
+		},
 		LatestReference: "mongo:4",
-		Description:     "Mongo is a database",
-		Tags:            []string{"docker"},
+		LatestAnnotations: oci.Annotations{
+			"version": "4.0.0",
+		},
+		Description: "Mongo is a database",
+		Tags:        []string{"docker"},
 		Links: []models.ImageLink{
 			{
 				Type: "docker",

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -110,15 +110,17 @@ func (w *Worker) ProcessRawImage(ctx context.Context, reference oci.Reference) e
 
 	log.DebugContext(ctx, "Running workflow")
 	data := &imageworkflow.Data{
-		ImageReference:  reference,
-		Image:           "",
-		LatestReference: nil,
-		Tags:            make([]string, 0),
-		Description:     "",
-		Links:           make([]models.ImageLink, 0),
-		Vulnerabilities: make([]models.ImageVulnerability, 0),
-		Graph:           image.Graph,
-		RegistryAuth:    w.registryAuth,
+		ImageReference:    reference,
+		Image:             "",
+		Annotations:       nil,
+		LatestReference:   nil,
+		LatestAnnotations: nil,
+		Tags:              make([]string, 0),
+		Description:       "",
+		Links:             make([]models.ImageLink, 0),
+		Vulnerabilities:   make([]models.ImageVulnerability, 0),
+		Graph:             image.Graph,
+		RegistryAuth:      w.registryAuth,
 	}
 
 	for _, tag := range image.Tags {
@@ -216,8 +218,10 @@ func (w *Worker) ProcessRawImage(ctx context.Context, reference oci.Reference) e
 	result := models.Image{
 		Reference:           data.ImageReference.String(),
 		Created:             data.Created,
+		Annotations:         data.Annotations,
 		LatestReference:     "",
 		LatestCreated:       data.LatestCreated,
+		LatestAnnotations:   data.LatestAnnotations,
 		VersionDiffSortable: versionDiffSortable,
 		Description:         data.Description,
 		Tags:                data.Tags,

--- a/internal/workflow/imageworkflow/data.go
+++ b/internal/workflow/imageworkflow/data.go
@@ -20,22 +20,24 @@ type Result[T any] struct {
 
 type Data struct {
 	sync.Mutex
-	ImageReference  oci.Reference
-	Created         *time.Time
-	Image           string
-	LatestReference *oci.Reference
-	LatestCreated   *time.Time
-	Tags            []string
-	Description     string
-	FullDescription Result[*models.ImageDescription]
-	ReleaseNotes    Result[*models.ImageReleaseNotes]
-	Links           []models.ImageLink
-	Vulnerabilities []models.ImageVulnerability
-	Graph           models.Graph
-	Scorecard       Result[*models.ImageScorecard]
-	Provenance      Result[*models.ImageProvenance]
-	SBOM            Result[*models.ImageSBOM]
-	RegistryAuth    *httputil.AuthMux
+	ImageReference    oci.Reference
+	Created           *time.Time
+	Image             string
+	Annotations       oci.Annotations
+	LatestReference   *oci.Reference
+	LatestCreated     *time.Time
+	LatestAnnotations oci.Annotations
+	Tags              []string
+	Description       string
+	FullDescription   Result[*models.ImageDescription]
+	ReleaseNotes      Result[*models.ImageReleaseNotes]
+	Links             []models.ImageLink
+	Vulnerabilities   []models.ImageVulnerability
+	Graph             models.Graph
+	Scorecard         Result[*models.ImageScorecard]
+	Provenance        Result[*models.ImageProvenance]
+	SBOM              Result[*models.ImageSBOM]
+	RegistryAuth      *httputil.AuthMux
 }
 
 func (d *Data) InsertTag(tag string) {

--- a/internal/workflow/imageworkflow/workflow.go
+++ b/internal/workflow/imageworkflow/workflow.go
@@ -67,6 +67,7 @@ func New(httpClient httputil.Requester, data *Data) workflow.Workflow {
 							return nil, err
 						}
 
+						data.Annotations = annotations
 						data.Description = annotations.Description()
 
 						if url := annotations.Source(); url != "" {
@@ -105,6 +106,8 @@ func New(httpClient httputil.Requester, data *Data) workflow.Workflow {
 						if err != nil {
 							return nil, err
 						}
+
+						data.LatestAnnotations = latestAnnotations
 
 						if latestAnnotations != nil {
 							time := latestAnnotations.Created()

--- a/web/lib/api/models.ts
+++ b/web/lib/api/models.ts
@@ -24,8 +24,10 @@ export interface PaginationMetadata {
 export interface Image {
   reference: string
   created?: string
+  annotations?: Record<string, string>
   latestReference?: string
   latestCreated?: string
+  latestAnnotations?: Record<string, string>
   description?: string
   tags: string[]
   links: ImageLink[]

--- a/web/oci.ts
+++ b/web/oci.ts
@@ -80,3 +80,36 @@ export function name(reference: string): string {
 
   return result.name
 }
+
+/**
+ * Returns a string representing the reference's version in a way users would
+ * normally associate with an image. If that ends up being a digest or the
+ * 'latest' tag, any known version annotation will be included in the string.
+ */
+export function formattedVersion(
+  reference: string,
+  annotations?: Record<string, string>
+): string {
+  let versionString = version(reference)
+  if (
+    (versionString === 'latest' || versionString.startsWith('sha256:')) &&
+    annotations
+  ) {
+    const versionAnnotationString = versionAnnotation(annotations)
+    if (versionAnnotationString) {
+      versionString = `${versionString} (${versionAnnotationString})`
+    }
+  }
+
+  return versionString
+}
+
+export function versionAnnotation(
+  annotations: Record<string, string>
+): string | undefined {
+  return (
+    annotations['org.opencontainers.image.version'] ||
+    annotations['org.label-schema.version'] ||
+    annotations.version
+  )
+}

--- a/web/pages/Dashboard.tsx
+++ b/web/pages/Dashboard.tsx
@@ -18,7 +18,7 @@ import {
   useSort,
 } from '../hooks'
 import { useImages, usePagination, useTags } from '../lib/api/ApiProvider'
-import { fullVersion, name, version } from '../oci'
+import { formattedVersion, fullVersion, name } from '../oci'
 import { DashboardSkeleton } from './dashboard-page/DashboardSkeleton'
 
 export function Dashboard(): JSX.Element {
@@ -286,10 +286,12 @@ export function Dashboard(): JSX.Element {
                 className={`group/link-focus:shadow-md hover:shadow-md transition-shadow-sm cursor-pointer dark:transition-colors group-focus/link:bg-[#f5f5f5] dark:group-focus/link:bg-[#262626] dark:hover:bg-[#262626] ${layout === 'list' ? '' : 'h-[150px]'}`}
                 reference={x.reference}
                 name={name(x.reference)}
-                currentVersion={version(x.reference)}
+                currentVersion={formattedVersion(x.reference, x.annotations)}
                 fullCurrentVersion={fullVersion(x.reference)}
                 latestVersion={
-                  x.latestReference ? version(x.latestReference) : undefined
+                  x.latestReference
+                    ? formattedVersion(x.latestReference, x.latestAnnotations)
+                    : undefined
                 }
                 fullLatestVersion={
                   x.latestReference ? fullVersion(x.latestReference) : undefined

--- a/web/pages/ImagePage.tsx
+++ b/web/pages/ImagePage.tsx
@@ -25,7 +25,7 @@ import {
   useLatestWorkflowRun,
   useTags,
 } from '../lib/api/ApiProvider'
-import { fullVersion, name, version } from '../oci'
+import { formattedVersion, fullVersion, name } from '../oci'
 import { compareTags } from '../tags'
 import { formatRelativeTimeTo } from '../time'
 import { Card } from './image-page/Card'
@@ -146,7 +146,10 @@ export function ImagePage(): JSX.Element {
                 className="font-medium max-w-[15ch] truncate"
                 title={fullVersion(image.value.reference)}
               >
-                {version(image.value.reference)}{' '}
+                {formattedVersion(
+                  image.value.reference,
+                  image.value.annotations
+                )}{' '}
               </p>
               <InfoTooltip
                 icon={<FluentWarning16Filled className="text-yellow-600" />}
@@ -161,7 +164,7 @@ export function ImagePage(): JSX.Element {
               className="font-medium max-w-[15ch] truncate"
               title={fullVersion(image.value.reference)}
             >
-              {version(image.value.reference)}
+              {formattedVersion(image.value.reference, image.value.annotations)}
             </p>
           ) : (
             <>
@@ -170,14 +173,20 @@ export function ImagePage(): JSX.Element {
                 className="font-medium text-red-600 max-w-[15ch] truncate"
                 title={fullVersion(image.value.reference)}
               >
-                {version(image.value.reference)}
+                {formattedVersion(
+                  image.value.reference,
+                  image.value.annotations
+                )}
               </p>
               <p
                 className="font-medium ml-4 text-green-600 max-w-[15ch] truncate"
                 title={fullVersion(image.value.latestReference)}
               >
                 {image.value.latestReference
-                  ? version(image.value.latestReference)
+                  ? formattedVersion(
+                      image.value.latestReference,
+                      image.value.latestAnnotations
+                    )
                   : 'unknown'}
               </p>
               <FluentChevronUp20Regular className="text-green-600" />


### PR DESCRIPTION
<img width="889" height="494" alt="image" src="https://github.com/user-attachments/assets/1965eef9-735f-46f1-a8e6-084df1a85fbf" />

Track OCI annotations for the image and the latest version of the image,
storing them to the database and exposing them through the API.

This enables us to include information from the annotations in the UI,
such as the version when using the 'latest' tag.

Solves: #398
