### PR TITLE
Fix collision issue in image update table

### DIFF
--- a/internal/store/init.go
+++ b/internal/store/init.go
@@ -11,7 +11,7 @@ import (
 	_ "embed" // Embed SQL files
 )
 
-const Revision = 9
+const Revision = 10
 
 //go:embed migrations
 var migrations embed.FS

--- a/internal/store/migrations/9.sql
+++ b/internal/store/migrations/9.sql
@@ -1,0 +1,71 @@
+-- Source revision: 9
+-- Target revision: 10
+-- Summary: Track changes to new versions
+
+-- TODO: Remove in v1
+
+DROP TABLE images_updates;
+DROP TRIGGER images_changes_images_insert_version;
+DROP TRIGGER images_changes_images_update_version;
+
+CREATE TABLE images_updates (
+  newReference TEXT NOT NULL,
+  newAnnotations BLOB,
+  oldReference TEXT NOT NULL,
+  oldAnnotations BLOB,
+  versionDiffSortable INT NOT NULL,
+  identified DATETIME NOT NULL,
+  released DATETIME,
+  PRIMARY KEY (newReference, oldReference)
+);
+
+-- Create an entry on INSERT with a newer version already identified
+CREATE TRIGGER images_changes_images_insert_version AFTER INSERT ON images WHEN
+    new.latestReference <> ""
+    AND new.latestReference <> new.reference
+  BEGIN
+  INSERT OR REPLACE INTO images_updates(
+    newReference,
+    newAnnotations,
+    oldReference,
+    oldAnnotations,
+    versionDiffSortable,
+    identified,
+    released
+  ) VALUES (
+    new.latestReference,
+    new.latestAnnotations,
+    new.reference,
+    new.annotations,
+    new.versionDiffSortable,
+    datetime('now', 'subsecond'),
+    new.latestCreated
+  );
+END;
+
+-- Create an entry on UPDATE with a newer version than what was known before
+CREATE TRIGGER images_changes_images_update_version AFTER UPDATE ON images WHEN
+    new.latestReference <> ""
+    AND new.latestReference <> old.latestReference
+    AND new.latestReference <> new.reference
+  BEGIN
+  INSERT OR REPLACE INTO images_updates(
+    newReference,
+    newAnnotations,
+    oldReference,
+    oldAnnotations,
+    versionDiffSortable,
+    identified,
+    released
+  ) VALUES (
+    new.latestReference,
+    new.latestAnnotations,
+    new.reference,
+    new.annotations,
+    new.versionDiffSortable,
+    datetime('now', 'subsecond'),
+    new.latestCreated
+  );
+END;
+
+INSERT INTO revision (id, revision) VALUES (0, 10) ON CONFLICT DO UPDATE SET revision=excluded.revision;

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1640,7 +1640,9 @@ type GetUpdateOptions struct {
 }
 
 func (s *Store) GetUpdates(ctx context.Context, options *GetUpdateOptions) ([]models.ImageUpdate, error) {
-	query := `SELECT newReference, newAnnotations, oldReference, oldAnnotations, identified, released FROM images_updates ORDER BY identified DESC`
+	// If the identified time is the same (to the precision stored), ensure the
+	// sort is stable by sorting by reference
+	query := `SELECT newReference, newAnnotations, oldReference, oldAnnotations, identified, released FROM images_updates ORDER BY identified DESC, newReference DESC, oldReference DESC`
 	parameters := []any{}
 	if options != nil && options.Limit != 0 {
 		query += ` LIMIT ?`


### PR DESCRIPTION
Fix a collision issue that occurred when the latest reference was not
unique in the images_updates table by creating a compound primary key of
the new and old references, ensuring the pairs are unique. Additionally,
replace entries on collision.

Add additional tests to replicate and regression test this change.

As a part of this change, the images_updates table is dropped and
recreated.
