### PR TITLE
Increase the timeout to prevent errors when displaying images with many tags

### DIFF
--- a/cmd/cupdate/worker.go
+++ b/cmd/cupdate/worker.go
@@ -21,7 +21,7 @@ func HandleScheduling(ctx context.Context, config *Config, processQueue *worker.
 			return
 		case <-ticker.C:
 			slog.Debug("Identifying old references to process")
-			ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			ctx, cancel := context.WithTimeout(ctx, 90*time.Second)
 			images, err := readStore.ListRawImages(ctx, &store.ListRawImagesOptions{
 				NotUpdatedSince: time.Now().Add(-config.Processing.MinAge),
 				Limit:           config.Processing.Items,


### PR DESCRIPTION
I get following errors and want to address the problem by increasing the timeout.

{"time":"2025-12-01T17:27:51.222826946Z","level":"ERROR","msg":"Failed to run image workflow","service.version":"v0.22.1-11-g10a9464","service.name":"cupdate","reference":"ghcr.io/immich-app/immich-machine-learning:v2.3.1@sha256:379e31b8c75107b0af8141904baa8cc933d7454b88fdb204265ef11749d7d908","error":"Get \"https://ghcr.io/token?scope=repository%3Aimmich-app%2Fimmich-machine-learning%3Apull&service=ghcr.io\": context deadline exceeded\ncontext deadline exceeded\ncontext deadline exceeded\ncontext deadline exceeded\ncontext deadline exceeded\ncontext deadline exceeded\ncontext deadline exceeded\ncontext deadline exceeded\ncontext deadline exceeded","code.file.path":"/src/internal/worker/worker.go","code.line.number":133,"code.function.name":"github.com/AlexGustafsson/cupdate/internal/worker.(*Worker).ProcessRawImage"}
{"time":"2025-12-01T17:27:51.224910184Z","level":"ERROR","msg":"Failed to insert image graph","service.version":"v0.22.1-11-g10a9464","service.name":"cupdate","reference":"ghcr.io/immich-app/immich-machine-learning:v2.3.1@sha256:379e31b8c75107b0af8141904baa8cc933d7454b88fdb204265ef11749d7d908","error":"context deadline exceeded","code.file.path":"/src/internal/worker/worker.go","code.line.number":266,"code.function.name":"github.com/AlexGustafsson/cupdate/internal/worker.(*Worker).ProcessRawImage"}
