### PR TITLE
Don't show version from annotation if duplicate

### DIFF
--- a/web/oci.ts
+++ b/web/oci.ts
@@ -96,7 +96,7 @@ export function formattedVersion(
     annotations
   ) {
     const versionAnnotationString = versionAnnotation(annotations)
-    if (versionAnnotationString) {
+    if (versionAnnotationString && versionAnnotationString !== versionString) {
       versionString = `${versionString} (${versionAnnotationString})`
     }
   }


### PR DESCRIPTION
Don't show the version from the annotation in the image card and image
page if the annotation matches the version itself. This fixes the case
where the version and the annotation is both "latest", leading the
displayed version to be shown as "latest (latest)".
