### PR TITLE
Add support for mapping mirrored references

### DIFF
--- a/cmd/cupdate/config.go
+++ b/cmd/cupdate/config.go
@@ -82,15 +82,17 @@ type Config struct {
 
 	Registry struct {
 		Secrets string `env:"SECRETS"`
+		Mirrors string `env:"MIRRORS"`
 	} `envPrefix:"REGISTRY_"`
 
 	Logos struct {
 		Path string `env:"PATH" envDefault:"logos"`
 	} `envPrefix:"LOGOS_"`
 
-	registryAuth *httputil.AuthMux
-	databaseURI  string
-	logLevel     slog.Level
+	registryAuth    *httputil.AuthMux
+	registryMirrors map[string]string
+	databaseURI     string
+	logLevel        slog.Level
 }
 
 // LogLevel returns the configured log level.
@@ -120,9 +122,17 @@ func (c *Config) parseLogLevel() error {
 
 // RegistryAuth returns the config to use when communicating with OCI
 // registries.
+//
 // Valid once the config has been parsed.
 func (c *Config) RegistryAuth() *httputil.AuthMux {
 	return c.registryAuth
+}
+
+// RegistryMirrors returns the mapping of registry mirrors.
+//
+// Valid once the config has been parsed.
+func (c *Config) RegistryMirrors() map[string]string {
+	return c.registryMirrors
 }
 
 func (c *Config) parseRegistryAuth() error {
@@ -133,10 +143,10 @@ func (c *Config) parseRegistryAuth() error {
 		if err != nil {
 			return fmt.Errorf("failed to read registry secrets: %w", err)
 		}
+		defer file.Close()
 
 		var dockerConfig *docker.ConfigFile
 		err = json.NewDecoder(file).Decode(&dockerConfig)
-		file.Close()
 		if err != nil {
 			return fmt.Errorf("failed to parse registry secrets: %w", err)
 		}
@@ -171,6 +181,29 @@ func (c *Config) parseRegistryAuth() error {
 	}
 
 	c.registryAuth = registryAuth
+	return nil
+}
+
+func (c *Config) parseRegistryMirrors() error {
+	if c.Registry.Mirrors == "" {
+		c.registryMirrors = make(map[string]string)
+	} else {
+		file, err := os.Open(c.Registry.Mirrors)
+		if err != nil {
+			return fmt.Errorf("failed to read registry mirrors: %w", err)
+		}
+		defer file.Close()
+
+		var dockerConfig struct {
+			Mirrors map[string]string `json:"mirrors"`
+		}
+		err = json.NewDecoder(file).Decode(&dockerConfig)
+		if err != nil {
+			return fmt.Errorf("failed to parse registry mirrors: %w", err)
+		}
+
+		c.registryMirrors = dockerConfig.Mirrors
+	}
 	return nil
 }
 
@@ -213,6 +246,10 @@ func ParseConfigFromEnv(environ []string) (*Config, error) {
 	}
 
 	if err := config.parseRegistryAuth(); err != nil {
+		return nil, err
+	}
+
+	if err := config.parseRegistryMirrors(); err != nil {
 		return nil, err
 	}
 

--- a/cmd/cupdate/main.go
+++ b/cmd/cupdate/main.go
@@ -100,7 +100,7 @@ func run(environ []string, signals <-chan os.Signal) ExitCode {
 		httpClient.UserAgent = config.HTTP.UserAgent
 		prometheus.DefaultRegisterer.MustRegister(httpClient)
 
-		worker := worker.New(httpClient, writeStore, config.RegistryAuth())
+		worker := worker.New(httpClient, writeStore, config.RegistryAuth(), config.RegistryMirrors())
 		prometheus.DefaultRegisterer.MustRegister(worker)
 
 		platformHub := events.NewHub[models.PlatformEvent]()

--- a/docs/config.md
+++ b/docs/config.md
@@ -5,35 +5,36 @@
 Cupdate requires zero configuration, but is very configurable. Configuration is
 done using environment variables.
 
-| Environment variable                    | Description                                                                                                           | Default                                               |
-| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| `CUPDATE_LOG_LEVEL`                     | `debug`, `info`, `warn`, `error`                                                                                      | `info`                                                |
-| `CUPDATE_API_ADDRESS`                   | The address to expose the API on.                                                                                     | `0.0.0.0`                                             |
-| `CUPDATE_API_PORT`                      | The port to expose the API on.                                                                                        | `8080`                                                |
-| `CUPDATE_WEB_DISABLED`                  | Whether or not to disable the web UI.                                                                                 | `false`                                               |
-| `CUPDATE_WEB_ADDRESS`                   | The URL at which the UI is available (such as `https://example.com`). Used for RSS feeds, should generally not be set | Automatically resolved.                               |
-| `CUPDATE_HTTP_USER_AGENT`               | The User Agent string to use for HTTP requests.                                                                       | `Cupdate/1.0`                                         |
-| `CUPDATE_CACHE_PATH`                    | A path to the boltdb file in which to store cache.                                                                    | `cachev1.boltdb`                                      |
-| `CUPDATE_CACHE_MAX_AGE`                 | The maximum age of cache entries.                                                                                     | `24h`                                                 |
-| `CUPDATE_DB_PATH`                       | A path to the sqlite file in which to store data.                                                                     | `dbv1.sqlite`                                         |
-| `CUPDATE_PROCESSING_INTERVAL`           | The interval between worker runs.                                                                                     | `1h`                                                  |
-| `CUPDATE_PROCESSING_ITEMS`              | The number of items (images) to process each worker run.                                                              | `10`                                                  |
-| `CUPDATE_PROCESSING_MIN_AGE`            | The minimum age of an item (image) before being processed.                                                            | `72h`                                                 |
-| `CUPDATE_PROCESSING_TIMEOUT`            | The maximum time one image may take to process before being terminated.                                               | `2m`                                                  |
-| `CUPDATE_PROCESSING_QUEUE_BURST`        | Number of items that can be processed in a short burst.                                                               | `10`                                                  |
-| `CUPDATE_PROCESSING_QUEUE_RATE`         | The desired processing rate under normal circumstances.                                                               | `1m`                                                  |
-| `CUPDATE_WORKFLOW_CLEANUP_MAX_AGE`      | The maximum age of a workflow run before it's removed.                                                                | `48h`                                                 |
-| `CUPDATE_WORKFLOW_CLEANUP_INTERVAL`     | The time between workflow run cleanup iterations.                                                                     | `1h`                                                  |
-| `CUPDATE_KUBERNETES_HOST`               | The host of the Kubernetes API. For use with proxying.                                                                | Required to use Kubernetes.                           |
-| `CUPDATE_KUBERNETES_DEBOUNCE_INTERVAL`  | The minimum time between graphs.                                                                                      | `1m`                                                  |
-| `CUPDATE_DOCKER_HOST`                   | One or more comma-separated Docker host URIs. Supports unix://path, tcp://host:port, http:// and https:// URIs.       | Required to use Docker.                               |
-| `CUPDATE_DOCKER_TLS_PATH`               | Path to a directory containing certificates and keys for Docker. See Docker-specific docs for details.                | Required to use Docker with mTLS or a self-signed CA. |
-| `CUPDATE_DOCKER_INCLUDE_ALL_CONTAINERS` | Whether or not to include containers in any state, not just running containers.                                       | `false`                                               |
-| `CUPDATE_OTEL_TARGET`                   | Target URL to an Open Telemetry GRPC ingest endpoint.                                                                 | Required to use Open Telemetry.                       |
-| `CUPDATE_OTEL_INSECURE`                 | Disable client transport security for the Open Telemetry GRPC connection.                                             | `false`                                               |
-| `CUPDATE_REGISTRY_SECRETS`              | Path to a JSON file containing registry secrets. See Docker's config.json and Kubernetes' `imagePullSecrets`.         | None.                                                 |
-| `CUPDATE_LOGOS_PATH`                    | Path to a directory from which to serve logo images.                                                                  | None.                                                 |
-| `CUPDATE_STATIC_FILE_PATH`              | Path to a file containing OCI references.                                                                             | None.                                                 |
+| Environment variable                    | Description                                                                                                              | Default                                               |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
+| `CUPDATE_LOG_LEVEL`                     | `debug`, `info`, `warn`, `error`                                                                                         | `info`                                                |
+| `CUPDATE_API_ADDRESS`                   | The address to expose the API on.                                                                                        | `0.0.0.0`                                             |
+| `CUPDATE_API_PORT`                      | The port to expose the API on.                                                                                           | `8080`                                                |
+| `CUPDATE_WEB_DISABLED`                  | Whether or not to disable the web UI.                                                                                    | `false`                                               |
+| `CUPDATE_WEB_ADDRESS`                   | The URL at which the UI is available (such as `https://example.com`). Used for RSS feeds, should generally not be set    | Automatically resolved.                               |
+| `CUPDATE_HTTP_USER_AGENT`               | The User Agent string to use for HTTP requests.                                                                          | `Cupdate/1.0`                                         |
+| `CUPDATE_CACHE_PATH`                    | A path to the boltdb file in which to store cache.                                                                       | `cachev1.boltdb`                                      |
+| `CUPDATE_CACHE_MAX_AGE`                 | The maximum age of cache entries.                                                                                        | `24h`                                                 |
+| `CUPDATE_DB_PATH`                       | A path to the sqlite file in which to store data.                                                                        | `dbv1.sqlite`                                         |
+| `CUPDATE_PROCESSING_INTERVAL`           | The interval between worker runs.                                                                                        | `1h`                                                  |
+| `CUPDATE_PROCESSING_ITEMS`              | The number of items (images) to process each worker run.                                                                 | `10`                                                  |
+| `CUPDATE_PROCESSING_MIN_AGE`            | The minimum age of an item (image) before being processed.                                                               | `72h`                                                 |
+| `CUPDATE_PROCESSING_TIMEOUT`            | The maximum time one image may take to process before being terminated.                                                  | `2m`                                                  |
+| `CUPDATE_PROCESSING_QUEUE_BURST`        | Number of items that can be processed in a short burst.                                                                  | `10`                                                  |
+| `CUPDATE_PROCESSING_QUEUE_RATE`         | The desired processing rate under normal circumstances.                                                                  | `1m`                                                  |
+| `CUPDATE_WORKFLOW_CLEANUP_MAX_AGE`      | The maximum age of a workflow run before it's removed.                                                                   | `48h`                                                 |
+| `CUPDATE_WORKFLOW_CLEANUP_INTERVAL`     | The time between workflow run cleanup iterations.                                                                        | `1h`                                                  |
+| `CUPDATE_KUBERNETES_HOST`               | The host of the Kubernetes API. For use with proxying.                                                                   | Required to use Kubernetes.                           |
+| `CUPDATE_KUBERNETES_DEBOUNCE_INTERVAL`  | The minimum time between graphs.                                                                                         | `1m`                                                  |
+| `CUPDATE_DOCKER_HOST`                   | One or more comma-separated Docker host URIs. Supports unix://path, tcp://host:port, http:// and https:// URIs.          | Required to use Docker.                               |
+| `CUPDATE_DOCKER_TLS_PATH`               | Path to a directory containing certificates and keys for Docker. See Docker-specific docs for details.                   | Required to use Docker with mTLS or a self-signed CA. |
+| `CUPDATE_DOCKER_INCLUDE_ALL_CONTAINERS` | Whether or not to include containers in any state, not just running containers.                                          | `false`                                               |
+| `CUPDATE_OTEL_TARGET`                   | Target URL to an Open Telemetry GRPC ingest endpoint.                                                                    | Required to use Open Telemetry.                       |
+| `CUPDATE_OTEL_INSECURE`                 | Disable client transport security for the Open Telemetry GRPC connection.                                                | `false`                                               |
+| `CUPDATE_REGISTRY_SECRETS`              | Path to a JSON file containing registry secrets. See Docker's config.json and Kubernetes' `imagePullSecrets`.            | None.                                                 |
+| `CUPDATE_REGISTRY_MIRRORS`              | Path to a JSON file containing registry mirror mapping in a `mirrors` object. Can be the same file as the Docker config. | None.                                                 |
+| `CUPDATE_LOGOS_PATH`                    | Path to a directory from which to serve logo images.                                                                     | None.                                                 |
+| `CUPDATE_STATIC_FILE_PATH`              | Path to a file containing OCI references.                                                                                | None.                                                 |
 
 ### Persistence
 
@@ -48,6 +49,60 @@ sqlite file itself: `<sqlite file>-shm` and `<sqlite file>-wal`.
 
 The cache path is specified using the `CUPDATE_CACHE_PATH` environment variable,
 which defaults to `cachev1.boltdb`.
+
+### Registry secrets, mirrors
+
+#### Secrets
+
+Cupdate can be configured to use a Docker config.json file via the
+`CUPDATE_REGISTRY_SECRETS` environment variable. The file follows the common
+format as used by Docker itself and platforms like Kubernetes. If it works
+with Docker or Kubernetes, it should work with Cupdate.
+
+A basic example for authenticating towards a local registry:
+
+```json
+{
+  "auths": {
+    "http://localhost:9090/v2/": {
+      "username": "username",
+      "password": "password"
+    }
+  }
+}
+```
+
+Other supported top-level fields are `HttpHeaders`. An "auth object" can also
+contain an `auth` value.
+
+#### Mirrors
+
+Cupdate supports mirrors by configuring the mapping of mirrored hostnames to
+their actual hostnames. Like with the registry secrets file, Cupdate takes a
+path to a JSON file in the `CUPDATE_REGISTRY_MIRRORS` environment variable.
+
+The file should contain a `mirrors` object like so:
+
+```jsonc
+{
+  "mirrors": {
+    // Tell Cupdate that images from mirror.gcr.io are actually from docker.io
+    "mirror.gcr.io": "docker.io",
+  },
+}
+```
+
+For convenience note that the file can be the same file as is used for registry
+secrets, but you still have to specify both environment variables.
+
+Note that this feature is mostly intended for _pull-through mirrors_. Cupdate
+will check the underlying registry for updates and assume that the mirror also
+serves the same image versions. If the mirror is configured to manually serve
+certain images and image versions, Cupdate might recommend versions found in the
+underlying registry that are unavailable from the mirror.
+
+Note that if the underlying registry requires authentication, you will need to
+configure a secret for that registry instead of the mirror.
 
 ### Labels
 

--- a/internal/oci/reference.go
+++ b/internal/oci/reference.go
@@ -28,7 +28,8 @@ type Reference struct {
 
 // Canonical converts the reference to its canonical form (i.e. with all fields
 // explicitly set to their implicit default value).
-// Panics if the refernece is invalid.
+// Panics if the reference is invalid.
+//
 // A reference returned by [ParseReference] is always canonical.
 func (r Reference) Canonical() Reference {
 	// ParseReference always canonicalizes the reference, reuse it
@@ -38,6 +39,16 @@ func (r Reference) Canonical() Reference {
 	}
 
 	return ref
+}
+
+// WithDomain returns the reference with the given domain.
+// Handles docker.io's "library" namespace conventions.
+func (r Reference) WithDomain(domain string) Reference {
+	r.Domain = domain
+	if domain == "docker.io" && !strings.Contains(r.Path, "/") {
+		r.Path = "library/" + r.Path
+	}
+	return r
 }
 
 // ParseReference parses a reference string.

--- a/internal/oci/reference_test.go
+++ b/internal/oci/reference_test.go
@@ -191,3 +191,41 @@ func TestReferenceCanonical(t *testing.T) {
 
 	assert.Equal(t, canonical, ref.Canonical())
 }
+
+func TestReference_WithDomain(t *testing.T) {
+	testCases := []struct {
+		Reference string
+
+		Domain            string
+		ExpectedReference string
+	}{
+		{
+			Reference: "mongo",
+
+			Domain:            "docker.io",
+			ExpectedReference: "mongo",
+		},
+		{
+			Reference: "mirror.gcr.io/mongo",
+
+			Domain:            "docker.io",
+			ExpectedReference: "mongo",
+		},
+		{
+			Reference: "mirror.gcr.io/b4bz/homer",
+
+			Domain:            "docker.io",
+			ExpectedReference: "b4bz/homer",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Reference, func(t *testing.T) {
+			reference, err := ParseReference(testCase.Reference)
+			require.NoError(t, err)
+
+			reference = reference.WithDomain(testCase.Domain)
+			assert.Equal(t, testCase.ExpectedReference, reference.String())
+		})
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -45,22 +45,24 @@ type Event struct {
 type Worker struct {
 	*events.Hub[Event]
 
-	httpClient   httputil.Requester
-	store        *store.Store
-	registryAuth *httputil.AuthMux
+	httpClient      httputil.Requester
+	store           *store.Store
+	registryAuth    *httputil.AuthMux
+	registryMirrors map[string]string
 
 	processedCounter   prometheus.Counter
 	processingDuration prometheus.Counter
 	processingGauge    prometheus.Gauge
 }
 
-func New(httpClient httputil.Requester, store *store.Store, registryAuth *httputil.AuthMux) *Worker {
+func New(httpClient httputil.Requester, store *store.Store, registryAuth *httputil.AuthMux, registryMirrors map[string]string) *Worker {
 	return &Worker{
 		Hub: events.NewHub[Event](),
 
-		httpClient:   httpClient,
-		store:        store,
-		registryAuth: registryAuth,
+		httpClient:      httpClient,
+		store:           store,
+		registryAuth:    registryAuth,
+		registryMirrors: registryMirrors,
 
 		processedCounter: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: "cupdate",
@@ -108,19 +110,26 @@ func (w *Worker) ProcessRawImage(ctx context.Context, reference oci.Reference) e
 		return err
 	}
 
+	// Map any mirrored references to their underlying image reference
+	underlyingReference := reference
+	if underlyingDomain, ok := w.registryMirrors[reference.Domain]; ok {
+		underlyingReference = reference.WithDomain(underlyingDomain)
+	}
+
 	log.DebugContext(ctx, "Running workflow")
 	data := &imageworkflow.Data{
-		ImageReference:    reference,
-		Image:             "",
-		Annotations:       nil,
-		LatestReference:   nil,
-		LatestAnnotations: nil,
-		Tags:              make([]string, 0),
-		Description:       "",
-		Links:             make([]models.ImageLink, 0),
-		Vulnerabilities:   make([]models.ImageVulnerability, 0),
-		Graph:             image.Graph,
-		RegistryAuth:      w.registryAuth,
+		ImageReference:           reference,
+		UnderlyingImageReference: underlyingReference,
+		Image:                    "",
+		Annotations:              nil,
+		LatestReference:          nil,
+		LatestAnnotations:        nil,
+		Tags:                     make([]string, 0),
+		Description:              "",
+		Links:                    make([]models.ImageLink, 0),
+		Vulnerabilities:          make([]models.ImageVulnerability, 0),
+		Graph:                    image.Graph,
+		RegistryAuth:             w.registryAuth,
 	}
 
 	for _, tag := range image.Tags {

--- a/internal/workflow/imageworkflow/data.go
+++ b/internal/workflow/imageworkflow/data.go
@@ -20,24 +20,25 @@ type Result[T any] struct {
 
 type Data struct {
 	sync.Mutex
-	ImageReference    oci.Reference
-	Created           *time.Time
-	Image             string
-	Annotations       oci.Annotations
-	LatestReference   *oci.Reference
-	LatestCreated     *time.Time
-	LatestAnnotations oci.Annotations
-	Tags              []string
-	Description       string
-	FullDescription   Result[*models.ImageDescription]
-	ReleaseNotes      Result[*models.ImageReleaseNotes]
-	Links             []models.ImageLink
-	Vulnerabilities   []models.ImageVulnerability
-	Graph             models.Graph
-	Scorecard         Result[*models.ImageScorecard]
-	Provenance        Result[*models.ImageProvenance]
-	SBOM              Result[*models.ImageSBOM]
-	RegistryAuth      *httputil.AuthMux
+	ImageReference           oci.Reference
+	UnderlyingImageReference oci.Reference
+	Created                  *time.Time
+	Image                    string
+	Annotations              oci.Annotations
+	LatestReference          *oci.Reference
+	LatestCreated            *time.Time
+	LatestAnnotations        oci.Annotations
+	Tags                     []string
+	Description              string
+	FullDescription          Result[*models.ImageDescription]
+	ReleaseNotes             Result[*models.ImageReleaseNotes]
+	Links                    []models.ImageLink
+	Vulnerabilities          []models.ImageVulnerability
+	Graph                    models.Graph
+	Scorecard                Result[*models.ImageScorecard]
+	Provenance               Result[*models.ImageProvenance]
+	SBOM                     Result[*models.ImageSBOM]
+	RegistryAuth             *httputil.AuthMux
 }
 
 func (d *Data) InsertTag(tag string) {

--- a/internal/workflow/imageworkflow/getlatestversion.go
+++ b/internal/workflow/imageworkflow/getlatestversion.go
@@ -19,6 +19,11 @@ func GetLatestReference() workflow.Step {
 				return nil, err
 			}
 
+			graphReference, err := workflow.GetInput[oci.Reference](ctx, "graphReference", true)
+			if err != nil {
+				return nil, err
+			}
+
 			registryClient, err := workflow.GetInput[*oci.Client](ctx, "registryClient", true)
 			if err != nil {
 				return nil, err
@@ -31,7 +36,7 @@ func GetLatestReference() workflow.Step {
 
 			// NOTE: The id of nodes is defined in the platform code
 			var labels platform.Labels
-			if root, ok := graph.Nodes["oci/image/"+reference.String()]; ok {
+			if root, ok := graph.Nodes["oci/image/"+graphReference.String()]; ok {
 				labels = root.Labels
 			}
 

--- a/internal/workflow/imageworkflow/workflow.go
+++ b/internal/workflow/imageworkflow/workflow.go
@@ -24,21 +24,22 @@ func New(httpClient httputil.Requester, data *Data) workflow.Workflow {
 					SetupRegistryClient().
 						WithID("registry").
 						With("httpClient", httpClient).
-						With("reference", data.ImageReference).
+						With("reference", data.UnderlyingImageReference).
 						With("registryAuth", data.RegistryAuth),
 					GetManifest().
 						WithID("manifest").
 						With("registryClient", workflow.Ref{Key: "step.registry.client"}).
-						With("reference", data.ImageReference),
+						With("reference", data.UnderlyingImageReference),
 					GetAnnotations().
 						WithID("annotations").
 						With("registryClient", workflow.Ref{Key: "step.registry.client"}).
-						With("reference", data.ImageReference).
+						With("reference", data.UnderlyingImageReference).
 						With("manifest", workflow.Ref{Key: "step.manifest.manifest"}),
 					GetLatestReference().
 						WithID("latest").
 						With("registryClient", workflow.Ref{Key: "step.registry.client"}).
-						With("reference", data.ImageReference).
+						With("reference", data.UnderlyingImageReference).
+						With("graphReference", data.ImageReference).
 						With("graph", data.Graph),
 					GetManifest().
 						WithID("latest-manifest").
@@ -100,7 +101,13 @@ func New(httpClient httputil.Requester, data *Data) workflow.Workflow {
 							return nil, err
 						}
 
-						data.LatestReference = reference
+						// As the latest reference might have been found using an underlying
+						// image reference (due to mirrors), ensure that the final domain
+						// is that of the mirror
+						{
+							r := (*reference).WithDomain(data.ImageReference.Domain)
+							data.LatestReference = &r
+						}
 
 						latestAnnotations, err := workflow.GetValue[oci.Annotations](ctx, "step.latest-annotations.annotations")
 						if err != nil {
@@ -128,16 +135,16 @@ func New(httpClient httputil.Requester, data *Data) workflow.Workflow {
 					GetAttestationManifests().
 						WithID("attestations").
 						With("registryClient", workflow.Ref{Key: "job.oci.step.registry.client"}).
-						With("reference", data.ImageReference),
+						With("reference", data.UnderlyingImageReference),
 					GetProvenanceAttestations().
 						WithID("provenance").
 						With("registryClient", workflow.Ref{Key: "job.oci.step.registry.client"}).
-						With("reference", data.ImageReference).
+						With("reference", data.UnderlyingImageReference).
 						With("manifests", workflow.Ref{Key: "step.attestations.manifests"}),
 					GetSBOMAttestations().
 						WithID("sbom").
 						With("registryClient", workflow.Ref{Key: "job.oci.step.registry.client"}).
-						With("reference", data.ImageReference).
+						With("reference", data.UnderlyingImageReference).
 						With("manifests", workflow.Ref{Key: "step.attestations.manifests"}),
 					workflow.Run(func(ctx workflow.Context) (workflow.Command, error) {
 						currentManifest, err := workflow.GetValue[any](ctx, "job.oci.step.manifest.manifest")
@@ -251,7 +258,7 @@ func New(httpClient httputil.Requester, data *Data) workflow.Workflow {
 				Steps: []workflow.Step{
 					DetermineSource().
 						WithID("source").
-						With("reference", data.ImageReference).
+						With("reference", data.UnderlyingImageReference).
 						With("annotations", workflow.Ref{Key: "job.oci.step.annotations.annotations"}).
 						With("attestations", workflow.Ref{Key: "job.attestations.step.provenance.attestations"}),
 				},
@@ -273,7 +280,7 @@ func New(httpClient httputil.Requester, data *Data) workflow.Workflow {
 					GetDockerHubRepository().
 						WithID("repository").
 						With("httpClient", httpClient).
-						With("reference", data.ImageReference),
+						With("reference", data.UnderlyingImageReference),
 					GetDockerHubRepositoryOwner().
 						WithID("owner").
 						With("httpClient", httpClient).
@@ -281,7 +288,7 @@ func New(httpClient httputil.Requester, data *Data) workflow.Workflow {
 					GetDockerHubVulnerabilities().
 						WithID("vulnerabilities").
 						With("httpClient", httpClient).
-						With("reference", data.ImageReference).
+						With("reference", data.UnderlyingImageReference).
 						With("manifest", workflow.Ref{Key: "job.oci.step.manifest.manifest"}),
 					workflow.Run(func(ctx workflow.Context) (workflow.Command, error) {
 						repository, err := workflow.GetValue[*dockerhub.Repository](ctx, "step.repository.repository")
@@ -341,7 +348,7 @@ func New(httpClient httputil.Requester, data *Data) workflow.Workflow {
 					GetGithubPackage().
 						WithID("package").
 						With("httpClient", httpClient).
-						With("reference", data.ImageReference),
+						With("reference", data.UnderlyingImageReference),
 					GetGitHubDescription().
 						WithID("description").
 						With("httpClient", httpClient).
@@ -359,7 +366,7 @@ func New(httpClient httputil.Requester, data *Data) workflow.Workflow {
 
 						data.InsertLink(models.ImageLink{
 							Type: "ghcr",
-							URL:  github.PackageURL(data.ImageReference),
+							URL:  github.PackageURL(data.UnderlyingImageReference),
 						})
 						data.Description = description
 
@@ -385,13 +392,13 @@ func New(httpClient httputil.Requester, data *Data) workflow.Workflow {
 				DependsOn: []string{},
 				// Only run for Quay images
 				If: func(ctx workflow.Context) (bool, error) {
-					return data.ImageReference.Domain == "quay.io", nil
+					return data.UnderlyingImageReference.Domain == "quay.io", nil
 				},
 				Steps: []workflow.Step{
 					GetQuayVulnerabilities().
 						WithID("vulnerabilities").
 						With("httpClient", httpClient).
-						With("reference", data.ImageReference),
+						With("reference", data.UnderlyingImageReference),
 					workflow.Run(func(ctx workflow.Context) (workflow.Command, error) {
 						vulnerabilities, err := workflow.GetValue[[]models.ImageVulnerability](ctx, "step.vulnerabilities.vulnerabilities")
 						if err != nil {
@@ -426,18 +433,18 @@ func New(httpClient httputil.Requester, data *Data) workflow.Workflow {
 				Steps: []workflow.Step{
 					GetGitLabDescription().
 						WithID("description").
-						With("reference", data.ImageReference).
+						With("reference", data.UnderlyingImageReference).
 						With("httpClient", httpClient),
 					GetGitLabRepositoryREADME().
 						WithID("readme").
-						With("reference", data.ImageReference).
+						With("reference", data.UnderlyingImageReference).
 						With("httpClient", httpClient),
 					workflow.Run(func(ctx workflow.Context) (workflow.Command, error) {
 						data.InsertTag("gitlab")
 
 						data.InsertLink(models.ImageLink{
 							Type: "gitlab",
-							URL:  "https://gitlab.com/" + data.ImageReference.Path,
+							URL:  "https://gitlab.com/" + data.UnderlyingImageReference.Path,
 						})
 
 						description, err := workflow.GetValue[string](ctx, "step.description.description")
@@ -502,7 +509,7 @@ func New(httpClient httputil.Requester, data *Data) workflow.Workflow {
 						if data.LatestReference != nil {
 							reference = *data.LatestReference
 						}
-						return workflow.SetOutput("reference", reference), nil
+						return workflow.SetOutput("reference", reference.WithDomain(data.UnderlyingImageReference.Domain)), nil
 					}).WithID("init"),
 					GetGitHubRepsitory().
 						WithID("repository").
@@ -564,7 +571,7 @@ func New(httpClient httputil.Requester, data *Data) workflow.Workflow {
 					GetGitHubAdvisoriesForRepository().
 						WithID("vulnerabilities").
 						With("httpClient", httpClient).
-						With("reference", data.ImageReference).
+						With("reference", data.UnderlyingImageReference).
 						With("owner", workflow.Ref{Key: "step.repository.owner"}).
 						With("repository", workflow.Ref{Key: "step.repository.name"}),
 					workflow.Run(func(ctx workflow.Context) (workflow.Command, error) {


### PR DESCRIPTION
Add support for mapping OCI image references from a mirror like
mirror.gcr.io to docker.io, letting Cupdate correctly enrich information
about such images.

Solves: #640
