### PR TITLE
Allow users to immediately scan images

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -293,7 +293,7 @@ paths:
   # like processing logs, time to process etc.
   /image/scans:
     post:
-      summary: Schedule a new scan.
+      summary: Schedule an immediate scan of the image.
       parameters:
         - in: query
           name: reference

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -277,6 +277,14 @@ func NewServer(
 		}
 
 		processQueue.PushFront(reference)
+		// NOTE: Adding a token for the processing of the item doesn't necessarily
+		// mean that the item will get processed as it's subject to races. For
+		// example, if another reference gets pushed simultaneously, it might get
+		// picked instead of the one pushed here. In practice, though, this is of
+		// little concern as such simultaneous access is incredibly rare and it
+		// would still mean that there's an additional token pushed, letting this
+		// reference get processed anyway
+		processQueue.AddTokens(1)
 		w.WriteHeader(http.StatusAccepted)
 	})
 

--- a/internal/worker/queue.go
+++ b/internal/worker/queue.go
@@ -19,6 +19,8 @@ type Queue[T comparable] struct {
 	cond    *sync.Cond
 	backlog []T
 	tokens  int
+	burst   int
+	close   chan struct{}
 	closed  bool
 
 	burstGauge  prometheus.Gauge
@@ -36,6 +38,8 @@ func NewQueue[T comparable](burst int, tick time.Duration) *Queue[T] {
 		cond:    sync.NewCond(&sync.Mutex{}),
 		backlog: make([]T, 0),
 		tokens:  burst,
+		burst:   burst,
+		close:   make(chan struct{}),
 
 		burstGauge: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: "cupdate",
@@ -54,22 +58,31 @@ func NewQueue[T comparable](burst int, tick time.Duration) *Queue[T] {
 		go func() {
 			ticker := time.NewTicker(tick)
 
-			for range ticker.C {
-				q.cond.L.Lock()
-				tokens := min(burst, q.tokens+1)
-				changed := tokens != q.tokens
-				q.tokens = tokens
-				q.cond.L.Unlock()
-
-				if changed {
-					q.burstGauge.Set(float64(tokens))
-					q.cond.Broadcast()
-				}
+			select {
+			case <-ticker.C:
+				q.AddTokens(1)
+			case <-q.close:
+				return
 			}
 		}()
 	}
 
 	return q
+}
+
+// AddTokens adds the specified number of tokens to the bucket, limited to the
+// configured burst.
+func (q *Queue[T]) AddTokens(tokens int) {
+	q.cond.L.Lock()
+	tokens = min(q.burst, q.tokens+1)
+	changed := tokens != q.tokens
+	q.tokens = tokens
+	q.cond.L.Unlock()
+
+	if changed {
+		q.burstGauge.Set(float64(tokens))
+		q.cond.Broadcast()
+	}
 }
 
 // PushFront puts one or more unique items at the front of the queue.
@@ -161,6 +174,9 @@ func (q *Queue[T]) AvailableBurst() int {
 func (q *Queue[T]) Close() {
 	q.cond.L.Lock()
 	defer q.cond.L.Unlock()
+	if !q.closed {
+		close(q.close)
+	}
 	q.closed = true
 	q.backlog = []T{}
 	q.cond.Broadcast()

--- a/internal/worker/queue_test.go
+++ b/internal/worker/queue_test.go
@@ -4,6 +4,7 @@ import (
 	"iter"
 	"slices"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/AlexGustafsson/cupdate/internal/oci"
@@ -96,28 +97,31 @@ func TestQueueNoBacklog(t *testing.T) {
 }
 
 func TestQueueMultipleConsumers(t *testing.T) {
-	// By having 1 burst we ensure that a worker will only pull a single item each
-	// time it's woken up, assuming it's quicker to process than the tick
-	q := NewQueue[int](1, 1*time.Millisecond)
-	defer q.Close()
+	synctest.Test(t, func(t *testing.T) {
+		// By having 1 burst we ensure that a worker will only pull a single item
+		// each time it's woken up, assuming it's quicker to process than the tick
+		q := NewQueue[int](1, 1*time.Second)
+		defer q.Close()
 
-	// Keep track of which worker handled with item
-	items := make([]int, 5)
-	for i := range 5 {
-		go func() {
-			for item := range q.Pull() {
-				items[item] = i
-			}
-		}()
-	}
+		// Keep track of which worker handled with item
+		items := make([]int, 5)
+		for i := range 5 {
+			go func() {
+				for item := range q.Pull() {
+					items[item] = i
+				}
+			}()
+		}
 
-	q.PushBack(0, 1, 2, 3, 4)
+		q.PushBack(0, 1, 2, 3, 4)
 
-	// Wait for all items to be processed
-	<-time.After(1 * time.Second)
+		// Wait for enough time to have passed for all items to have been processed
+		<-time.After(6 * time.Second)
+		synctest.Wait()
 
-	slices.Sort(items)
-	assert.NotEqual(t, items[0], items[4], "different workers handled requests")
+		slices.Sort(items)
+		assert.NotEqual(t, items[0], items[4], "different workers handled requests")
+	})
 }
 
 func TestQueueClose(t *testing.T) {
@@ -168,4 +172,40 @@ func TestQueueDeduplication(t *testing.T) {
 	ref.Tag = "5"
 	q.PushBack(ref)
 	assert.Equal(t, 2, q.Len())
+}
+
+func TestQueueAddTokens(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// By having 1 burst we ensure that a worker will only pull a single item
+		// each time it's woken up, assuming it's quicker to process than the tick.
+		// By setting the tick to something big, we can control it manually
+		q := NewQueue[int](1, 1*time.Hour)
+		defer q.Close()
+
+		// Keep track of consumed items
+		items := make([]int, 0, 2)
+		go func() {
+			for item := range q.Pull() {
+				items = append(items, item)
+			}
+		}()
+
+		// Right off the bat there's one token to consume. Thus, pushing an item and
+		// waiting a few seconds should leave the sole item consumed
+		q.PushBack(0)
+		<-time.After(5 * time.Second)
+		synctest.Wait()
+		assert.Equal(t, []int{0}, items)
+
+		// Pushing another item and waiting for a while leaves the item unprocessed
+		q.PushBack(1)
+		<-time.After(5 * time.Second)
+		synctest.Wait()
+		assert.Equal(t, []int{0}, items)
+
+		// Adding a token processes the item ASAP
+		q.AddTokens(1)
+		synctest.Wait()
+		assert.Equal(t, []int{0, 1}, items)
+	})
 }


### PR DESCRIPTION
**Immediately process manual image scans**
    
The manual image scan API trigger let users side step the scheduling of
image scans. It did however require the worker queue to have available
tokens for the processing of the image.

This change always adds a token to the queue when an image is manually
scheduled for processing, meaning it will get processed ASAP.

Solves concerns raised in #642.

**Add support for adding tokens to worker queue**
    
Expose the ability to add tokens to the worker queue in a safe way. This
allows for users to effectively bypass the queue's tick.

This is useful when scheduling items for immediate processing without
sidestepping the queue.

Additionally, synctest is used in existing and new tests to make them
faster and less flakey