### PR TITLE
Fix image workflow test case

### DIFF
--- a/internal/workflow/imageworkflow/workflow_test.go
+++ b/internal/workflow/imageworkflow/workflow_test.go
@@ -28,16 +28,20 @@ func TestWorkflow(t *testing.T) {
 
 	httpClient := httputil.NewClient(cache, 5*time.Minute)
 
-	reference, err := oci.ParseReference("mongo:4")
+	reference, err := oci.ParseReference("mirror.gcr.io/mongo:4")
+	require.NoError(t, err)
+
+	underlyingReference, err := oci.ParseReference("mongo:4")
 	require.NoError(t, err)
 
 	data := &Data{
-		ImageReference:  reference,
-		Image:           "",
-		LatestReference: &reference,
-		Tags:            make([]string, 0),
-		Links:           make([]models.ImageLink, 0),
-		RegistryAuth:    httputil.NewAuthMux(),
+		ImageReference:           reference,
+		UnderlyingImageReference: underlyingReference,
+		Image:                    "",
+		LatestReference:          &reference,
+		Tags:                     make([]string, 0),
+		Links:                    make([]models.ImageLink, 0),
+		RegistryAuth:             httputil.NewAuthMux(),
 	}
 
 	workflow := New(httpClient, data)


### PR DESCRIPTION
The image workflow test cases are not run in the CI pipeline as they can
perform quite a lot of network requests, meaning that they can be spammy
and easily flakey.

When adding support for mirrors in 7cf1ade, one of these test cases
started failing due to lacking the new underlying image reference field.

This is now fixed.
