### PR TITLE
Expose unprocessed images as images

### DIFF
--- a/cmd/cupdate/graph.go
+++ b/cmd/cupdate/graph.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
+	"time"
 
 	"github.com/AlexGustafsson/cupdate/internal/events"
 	"github.com/AlexGustafsson/cupdate/internal/models"
@@ -146,7 +148,7 @@ func HandleGraphs(ctx context.Context, targetPlatform platform.ContinuousGrapher
 
 				rawImage := &models.RawImage{
 					Reference: imageNode.Reference.String(),
-					Tags:      tags,
+					Tags:      slices.Clone(tags),
 					Graph:     mappedGraph,
 				}
 
@@ -156,6 +158,19 @@ func HandleGraphs(ctx context.Context, targetPlatform platform.ContinuousGrapher
 				if err != nil {
 					slog.Error("Failed to insert raw image", slog.Any("error", err))
 					continue
+				}
+
+				image := &models.Image{
+					Reference:    imageNode.Reference.String(),
+					Tags:         append(slices.Clone(tags), "unprocessed"),
+					LastModified: time.Now(),
+				}
+
+				slog.Debug("Inserting raw image as unprocessed image", slog.String("reference", image.Reference))
+				err = writeStore.InsertImage(ctx, image, true)
+				if err != nil {
+					slog.Error("Failed to insert raw image as unprocessed image", slog.Any("error", err))
+					// Fallthrough - scheduling will process it eventually
 				}
 
 				// Try to schedule the image for processing

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -299,6 +299,11 @@ func NewServer(
 		reference := query.Get("reference")
 
 		response, err := api.GetLatestWorkflowRun(ctx, reference)
+		if response == nil && err == nil {
+			s.handleGenericResponse(w, r, ErrNotFound)
+			return
+		}
+
 		s.handleJSONResponse(w, r, response, err)
 	})
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -211,7 +211,7 @@ func (s *Store) ListRawImages(ctx context.Context, options *ListRawImagesOptions
 	return rawImages, nil
 }
 
-func (s *Store) InsertImage(ctx context.Context, image *models.Image) error {
+func (s *Store) InsertImage(ctx context.Context, image *models.Image, ifNotExists bool) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
@@ -220,11 +220,13 @@ func (s *Store) InsertImage(ctx context.Context, image *models.Image) error {
 		return err
 	}
 
-	statement, err := tx.PrepareContext(ctx, `INSERT INTO images
-	(reference, created, annotations, latestReference, latestCreated, latestAnnotations, versionDiffSortable, description, lastModified, imageUrl)
-	VALUES
-	(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	ON CONFLICT(reference) DO UPDATE SET
+	// NOTE: This text is directly inserted into the prepared statement. It must
+	// not include user-supplied strings
+	onConflictClause := ""
+	if ifNotExists {
+		onConflictClause = `DO NOTHING`
+	} else {
+		onConflictClause = `DO UPDATE SET
 		created=excluded.created,
 		annotations=excluded.annotations,
 		latestReference=excluded.latestReference,
@@ -233,8 +235,14 @@ func (s *Store) InsertImage(ctx context.Context, image *models.Image) error {
 		versionDiffSortable=excluded.versionDiffSortable,
 		description=excluded.description,
 		lastModified=excluded.lastModified,
-		imageUrl=excluded.imageUrl
-	;`)
+		imageUrl=excluded.imageUrl`
+	}
+
+	statement, err := tx.PrepareContext(ctx, `INSERT INTO images
+	(reference, created, annotations, latestReference, latestCreated, latestAnnotations, versionDiffSortable, description, lastModified, imageUrl)
+	VALUES
+	(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	ON CONFLICT(reference) `+onConflictClause+";")
 	if err != nil {
 		tx.Rollback()
 		return err
@@ -266,11 +274,25 @@ func (s *Store) InsertImage(ctx context.Context, image *models.Image) error {
 		latestAnnotations = &encodedString
 	}
 
-	_, err = statement.ExecContext(ctx, image.Reference, image.Created, annotations, latestReference, image.LatestCreated, latestAnnotations, image.VersionDiffSortable, image.Description, image.LastModified, image.Image)
+	result, err := statement.ExecContext(ctx, image.Reference, image.Created, annotations, latestReference, image.LatestCreated, latestAnnotations, image.VersionDiffSortable, image.Description, image.LastModified, image.Image)
 	statement.Close()
 	if err != nil {
 		tx.Rollback()
 		return err
+	}
+
+	// If the image should only be inserted if it didn't already exist, bail
+	// unless the row was not inserted for the first time
+	affected, err := result.RowsAffected()
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	if ifNotExists && affected == 0 {
+		// NOTE: At this point, nothing's been modified, but rollback has a clearer
+		// intent than commit
+		tx.Rollback()
+		return nil
 	}
 
 	// First clear out tags for an easy way of removing those that are no longer
@@ -513,6 +535,10 @@ func (s *Store) GetImagesLinks(ctx context.Context, reference string) ([]models.
 	var links []models.ImageLink
 	if err := json.Unmarshal(serializedLinks, &links); err != nil {
 		return nil, err
+	}
+
+	if links == nil {
+		links = make([]models.ImageLink, 0)
 	}
 
 	return links, nil

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -78,7 +78,7 @@ func TestStoreInsertImage(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = store.InsertImage(t.Context(), expected)
+	err = store.InsertImage(t.Context(), expected, false)
 	require.NoError(t, err)
 
 	actual, err := store.GetImage(t.Context(), "mongo:4")
@@ -86,7 +86,7 @@ func TestStoreInsertImage(t *testing.T) {
 	assert.EqualValues(t, expected, actual)
 
 	// Make sure triggers don't complain when upserting
-	err = store.InsertImage(t.Context(), expected)
+	err = store.InsertImage(t.Context(), expected, false)
 	require.NoError(t, err)
 
 	changes, err := store.GetChanges(t.Context(), nil)
@@ -123,7 +123,7 @@ func TestStoreTags(t *testing.T) {
 	err = store.InsertImage(t.Context(), &models.Image{
 		Reference: "mongo:4",
 		Tags:      []string{"docker"},
-	})
+	}, false)
 	require.NoError(t, err)
 
 	actual, err := store.GetTags(t.Context())
@@ -146,7 +146,7 @@ func TestStoreImageDescription(t *testing.T) {
 
 	err = store.InsertImage(t.Context(), &models.Image{
 		Reference: "mongo:4",
-	})
+	}, false)
 	require.NoError(t, err)
 
 	err = store.InsertImageDescription(t.Context(), "mongo:4", &expected)
@@ -197,7 +197,7 @@ func TestStoreImageReleaseNotes(t *testing.T) {
 
 	err = store.InsertImage(t.Context(), &models.Image{
 		Reference: "mongo:4",
-	})
+	}, false)
 	require.NoError(t, err)
 
 	err = store.InsertImageReleaseNotes(t.Context(), "mongo:4", &expected)
@@ -262,7 +262,7 @@ func TestStoreImageGraph(t *testing.T) {
 
 	err = store.InsertImage(t.Context(), &models.Image{
 		Reference: "mongo:4",
-	})
+	}, false)
 	require.NoError(t, err)
 
 	err = store.InsertImageGraph(t.Context(), "mongo:4", &expected)
@@ -339,7 +339,7 @@ func TestListImages(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		err = store.InsertImage(t.Context(), &image)
+		err = store.InsertImage(t.Context(), &image, false)
 		require.NoError(t, err)
 	}
 
@@ -445,7 +445,7 @@ func TestListImagesQuery(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		err = store.InsertImage(t.Context(), &image)
+		err = store.InsertImage(t.Context(), &image, false)
 		require.NoError(t, err)
 	}
 
@@ -523,7 +523,7 @@ func TestStoreDeleteNonPresent(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		err = store.InsertImage(t.Context(), image)
+		err = store.InsertImage(t.Context(), image, false)
 		require.NoError(t, err)
 	}
 
@@ -561,11 +561,11 @@ func TestStoreUpdateImageReference(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = store.InsertImage(t.Context(), image)
+	err = store.InsertImage(t.Context(), image, false)
 	require.NoError(t, err)
 
 	image.LatestReference = "mongo:5"
-	err = store.InsertImage(t.Context(), image)
+	err = store.InsertImage(t.Context(), image, false)
 	require.NoError(t, err)
 
 	changes, err := store.GetChanges(t.Context(), nil)
@@ -615,7 +615,7 @@ func TestInsertWorkflowRun(t *testing.T) {
 		LastModified:    time.Date(2024, 10, 05, 18, 39, 0, 0, time.Local).UTC(),
 	}
 
-	err = store.InsertImage(t.Context(), image)
+	err = store.InsertImage(t.Context(), image, false)
 	require.NoError(t, err)
 
 	expected := models.WorkflowRun{
@@ -682,7 +682,7 @@ func TestCascadeDelete(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = store.InsertImage(t.Context(), image)
+	err = store.InsertImage(t.Context(), image, false)
 	require.NoError(t, err)
 
 	err = store.InsertImageDescription(t.Context(), image.Reference, &models.ImageDescription{
@@ -774,7 +774,7 @@ func TestStoreGetUpdates(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = store.InsertImage(t.Context(), base1)
+	err = store.InsertImage(t.Context(), base1, false)
 	require.NoError(t, err)
 
 	base2 := &models.Image{
@@ -795,7 +795,7 @@ func TestStoreGetUpdates(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = store.InsertImage(t.Context(), base2)
+	err = store.InsertImage(t.Context(), base2, false)
 	require.NoError(t, err)
 
 	// Insert image updates (test UPDATE)
@@ -817,7 +817,7 @@ func TestStoreGetUpdates(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = store.InsertImage(t.Context(), updated1)
+	err = store.InsertImage(t.Context(), updated1, false)
 	require.NoError(t, err)
 
 	updated2 := &models.Image{
@@ -838,7 +838,7 @@ func TestStoreGetUpdates(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = store.InsertImage(t.Context(), updated2)
+	err = store.InsertImage(t.Context(), updated2, false)
 	require.NoError(t, err)
 
 	// Expect there to be updates
@@ -895,4 +895,60 @@ func TestStoreGetUpdates(t *testing.T) {
 			Released:   &update1ReleasedAt,
 		},
 	}, updates)
+}
+
+func TestStoreInsertUnprocessedImage(t *testing.T) {
+	store := newStore(t, false)
+	defer store.Close()
+
+	_, err := store.InsertRawImage(t.Context(), &models.RawImage{
+		Reference: "mongo:4",
+	})
+	require.NoError(t, err)
+
+	// Insert a processed image
+	err = store.InsertImage(t.Context(), &models.Image{
+		Reference: "mongo:4",
+		Tags:      []string{"some tag"},
+	}, false)
+	require.NoError(t, err)
+
+	// Try to insert an unprocessed image, expecting it to succeed but change
+	// nothing
+	err = store.InsertImage(t.Context(), &models.Image{
+		Reference: "mongo:4",
+		Tags:      []string{"unprocessed"},
+	}, true)
+	require.NoError(t, err)
+
+	actual, err := store.GetImage(t.Context(), "mongo:4")
+	require.NoError(t, err)
+	assert.EqualValues(t, &models.Image{
+		Reference:    "mongo:4",
+		Tags:         []string{"some tag"},
+		Links:        []models.ImageLink{},
+		LastModified: actual.LastModified, // Difficult to assert
+	}, actual)
+
+	// Try to insert another unprocessed image, expecting it to succeed as there's
+	// no existing image
+	_, err = store.InsertRawImage(t.Context(), &models.RawImage{
+		Reference: "mongo:5",
+	})
+	require.NoError(t, err)
+
+	err = store.InsertImage(t.Context(), &models.Image{
+		Reference: "mongo:5",
+		Tags:      []string{"unprocessed"},
+	}, true)
+	require.NoError(t, err)
+
+	actual, err = store.GetImage(t.Context(), "mongo:5")
+	require.NoError(t, err)
+	assert.EqualValues(t, &models.Image{
+		Reference:    "mongo:5",
+		Tags:         []string{"unprocessed"},
+		Links:        []models.ImageLink{},
+		LastModified: actual.LastModified, // Difficult to assert
+	}, actual)
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -242,7 +242,7 @@ func (w *Worker) ProcessRawImage(ctx context.Context, reference oci.Reference) e
 	if data.LatestReference != nil {
 		result.LatestReference = data.LatestReference.String()
 	}
-	if err := w.store.InsertImage(ctx, &result); err != nil {
+	if err := w.store.InsertImage(ctx, &result, false); err != nil {
 		log.ErrorContext(ctx, "Failed to insert image", slog.Any("error", err))
 		// Fallthrough - try to insert what we have
 	}

--- a/web/components/ImageCard.tsx
+++ b/web/components/ImageCard.tsx
@@ -105,9 +105,10 @@ export function ImageCard({
                   <InfoTooltip
                     icon={<FluentWarning16Filled className="text-yellow-600" />}
                   >
-                    The latest version cannot be identified. This could be due
-                    to the image not being available, the registry not being
-                    supported, missing authentication or a temporary issue.
+                    The latest version hasn't been identified. This could be due
+                    to the image not being processed yet, not being available,
+                    the registry not being supported, missing authentication or
+                    a temporary issue.
                   </InfoTooltip>
                 )}
               </>

--- a/web/lib/api/models.ts
+++ b/web/lib/api/models.ts
@@ -23,6 +23,7 @@ export interface PaginationMetadata {
 
 export interface Image {
   reference: string
+  processed: boolean
   created?: string
   annotations?: Record<string, string>
   latestReference?: string

--- a/web/pages/ImagePage.tsx
+++ b/web/pages/ImagePage.tsx
@@ -194,9 +194,10 @@ export function ImagePage(): JSX.Element {
               <InfoTooltip
                 icon={<FluentWarning16Filled className="text-yellow-600" />}
               >
-                The latest version cannot be identified. This could be due to
-                the image not being available, the registry not being supported,
-                missing authentication or a temporary issue.
+                The latest version hasn't been identified. This could be due to
+                the image not being processed yet, not being available, the
+                registry not being supported, missing authentication or a
+                temporary issue.
               </InfoTooltip>
             </>
           ) : image.value.reference === image.value.latestReference ? (

--- a/web/pages/image-page/ProcessStatus.tsx
+++ b/web/pages/image-page/ProcessStatus.tsx
@@ -7,12 +7,12 @@ import { useScheduleScan } from '../../lib/api/ApiProvider'
 import { formatRelativeTimeTo } from '../../time'
 
 type ProcessStatusProps = {
-  lastModified: string
+  lastProcessed: string | undefined
   reference: string
 }
 
 export function ProcessStatus({
-  lastModified: initialLastModified,
+  lastProcessed: initialLastProcessed,
   reference,
 }: ProcessStatusProps): JSX.Element {
   const scheduleScan = useScheduleScan()
@@ -22,8 +22,8 @@ export function ProcessStatus({
   >('idle')
 
   // Get the time from the image once, then rely on events to update it
-  const [lastModified, setLastModified] = useState(
-    new Date(initialLastModified)
+  const [lastProcessed, setLastProcessed] = useState(
+    initialLastProcessed ? new Date(initialLastProcessed) : undefined
   )
 
   const onSchedule = useCallback(() => {
@@ -37,7 +37,7 @@ export function ProcessStatus({
     (e) => {
       if (e.type === 'imageProcessed' && e.reference === reference) {
         // TODO: Use time from event rather then the current time
-        setLastModified(new Date())
+        setLastProcessed(new Date())
 
         // If we successfully queued the image for processing, clear the state
         // when the reference was processed
@@ -51,14 +51,17 @@ export function ProcessStatus({
 
   return (
     <div className="flex justify-center">
-      {status !== 'successful' && (
-        <p>
-          Last processed{' '}
-          <span title={lastModified.toLocaleString()}>
-            {formatRelativeTimeTo(lastModified)}
-          </span>
-        </p>
-      )}
+      {status !== 'successful' &&
+        (lastProcessed ? (
+          <p>
+            Last processed{' '}
+            <span title={lastProcessed.toLocaleString()}>
+              {formatRelativeTimeTo(lastProcessed)}
+            </span>
+          </p>
+        ) : (
+          <p>Awaiting processing</p>
+        ))}
       <p>{status === 'successful' && 'Image is scheduled for processing'}</p>
       <button
         type="button"

--- a/web/pages/image-page/WorkflowCard.tsx
+++ b/web/pages/image-page/WorkflowCard.tsx
@@ -251,7 +251,7 @@ export function WorkflowCard({
               )}
               <ProcessStatus
                 reference={reference}
-                lastModified={lastModified}
+                lastProcessed={workflowRun ? lastModified : undefined}
               />
             </>
           ),

--- a/web/tags.ts
+++ b/web/tags.ts
@@ -242,6 +242,11 @@ export const Tags: Tag[] = [
     description: 'Up-to-date images',
     color: palette.positive,
   },
+  {
+    name: 'unprocessed',
+    description: 'Unprocessed images',
+    color: palette.warning,
+  },
 
   // Security information
   {


### PR DESCRIPTION
When discovering new images, store them as images without any additional
data (apart from tags), until the image can be processed.

This allows users to see all images, some of which might not just be
enriched yet.

Alternatives were considered, but by storing them alongside regular
images, very little code needed to be changed and the overall flow of
data remains the same.

To easily identify the images in the UI and API, an "unprocessed" tag is
introduced.

Solves concerns raised in #640.
