### PR TITLE
Skip removed images after workflow processing

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -141,6 +141,12 @@ func (s *Store) GetRawImage(ctx context.Context, reference string) (*models.RawI
 	return &rawImage, nil
 }
 
+func (s *Store) RawImageExists(ctx context.Context, reference string) (bool, error) {
+	var exists bool
+	err := s.db.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM raw_images WHERE reference = ?);`, reference).Scan(&exists)
+	return exists, err
+}
+
 type ListRawImagesOptions struct {
 	NotUpdatedSince time.Time
 	Limit           int

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -222,6 +222,15 @@ func (w *Worker) ProcessRawImage(ctx context.Context, reference oci.Reference) e
 		}
 	}
 
+	exists, err := w.store.RawImageExists(ctx, reference.String())
+	if err != nil {
+		return err
+	}
+	if !exists {
+		log.DebugContext(ctx, "Image removed during processing")
+		return nil
+	}
+
 	timeBeforeInsert := time.Now()
 
 	result := models.Image{

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -1,0 +1,75 @@
+package worker
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"net/http"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/AlexGustafsson/cupdate/internal/httputil"
+	"github.com/AlexGustafsson/cupdate/internal/models"
+	"github.com/AlexGustafsson/cupdate/internal/oci"
+	"github.com/AlexGustafsson/cupdate/internal/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type removingRequester struct {
+	store *store.Store
+	once  sync.Once
+}
+
+func (r *removingRequester) Do(req *http.Request) (*http.Response, error) {
+	var err error
+	r.once.Do(func() {
+		_, err = r.store.DeleteNonPresent(req.Context(), nil)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, errors.New("stop workflow after removing image")
+}
+
+func (r *removingRequester) DoCached(req *http.Request) (*http.Response, error) {
+	return r.Do(req)
+}
+
+func TestProcessRawImageRemovedDuringWorkflow(t *testing.T) {
+	uri := "file:" + filepath.ToSlash(filepath.Join(t.TempDir(), "sqlite.db"))
+	require.NoError(t, store.Initialize(t.Context(), uri))
+
+	store, err := store.New(t.Context(), uri, false)
+	require.NoError(t, err)
+	defer store.Close()
+
+	reference, err := oci.ParseReference("example.com/test/image:latest")
+	require.NoError(t, err)
+
+	_, err = store.InsertRawImage(t.Context(), &models.RawImage{
+		Reference: reference.String(),
+	})
+	require.NoError(t, err)
+	exists, err := store.RawImageExists(t.Context(), reference.String())
+	require.NoError(t, err)
+	require.True(t, exists)
+
+	var logs bytes.Buffer
+	logger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() {
+		slog.SetDefault(logger)
+	})
+
+	worker := New(&removingRequester{store: store}, store, httputil.NewAuthMux(), nil)
+	require.NoError(t, worker.ProcessRawImage(t.Context(), reference))
+
+	assert.Contains(t, logs.String(), "Image removed during processing")
+	assert.NotContains(t, logs.String(), "FOREIGN KEY constraint failed")
+	exists, err = store.RawImageExists(t.Context(), reference.String())
+	require.NoError(t, err)
+	assert.False(t, exists)
+}


### PR DESCRIPTION
Fixes #446.

`ProcessRawImage` can finish after platform reconciliation has removed its raw image. This rechecks the parent immediately before persistence and treats the stale job as a debug-level outcome instead of attempting foreign-key-constrained writes.

Tests:
- `go test -p=1 -count=10 -short ./internal/worker -run '^TestProcessRawImageRemovedDuringWorkflow$'`
- `go test -p=1 -short -v ./internal/worker`

Local boundaries: the repository-wide short suite hits pre-existing Windows path and file-lock failures, and `-race` requires CGO, so the Linux/race matrix remains for CI.
