### PR TITLE
Update memory limit in Kubernetes manifests

### DIFF
--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -47,7 +47,7 @@ spec:
               cpu: "0.01"
               memory: "32Mi"
             limits:
-              memory: "128Mi"
+              memory: "256Mi"
           livenessProbe:
             httpGet:
               path: /livez


### PR DESCRIPTION
When processing huge SBOMs, osv-scanner can use a lot of memory. This in
turn affects Cupdate's memory footprint.

Though normally reasource friendly, increase the memory limit to 256Mi
to not get OOM killed when processing such SBOMs.
